### PR TITLE
feat: 인증 저장 콘텐츠 API 계약 정리

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -2,11 +2,13 @@ import { createServer, type Server as HttpServer } from "node:http";
 import express, { type Express } from "express";
 import cors from "cors";
 import { Server, type Server as SocketServer } from "socket.io";
-import type { PlayerSave, WorldContent } from "@rpg/game-core";
+import type { BootstrapPayload, HealthPayload, PlayerPayload, PlayerSave, WorldContent } from "@rpg/game-core";
 import { migrateLegacyPlayerSave } from "@rpg/game-core";
 import type { ServerEnv } from "./config/env";
 import { loadWorld } from "./content/world";
 import { authMiddleware, assertPlayerOwnership, type AuthenticatedRequest, loginHandler, registerHandler } from "./http/auth";
+import { createRouteError, route, sendSuccess } from "./http/response";
+import { readPlayerSave } from "./http/validation";
 import { configureRealtime } from "./realtime/presence";
 import type { UserRepository } from "./storage";
 
@@ -23,47 +25,47 @@ export async function createAppContext(options: {
   app.use(cors({ origin: env.clientOrigin, credentials: true }));
   app.use(express.json({ limit: "1mb" }));
 
-  app.get("/healthz", (_req, res) => {
-    res.json({ success: true });
-  });
+  app.get("/healthz", route(async (_req, res) => {
+    const payload: HealthPayload = { status: "ok" };
+    sendSuccess(res, payload);
+  }));
 
-  app.get("/content/bootstrap", async (_req, res) => {
+  app.get("/content/bootstrap", route(async (_req, res) => {
     const world = await worldLoader();
-    res.json({ success: true, world });
-  });
+    const payload: BootstrapPayload = { world };
+    sendSuccess(res, payload);
+  }));
 
-  app.post("/auth/register", async (req, res) => {
+  app.post("/auth/register", route(async (req, res) => {
     await registerHandler(req, res, repository, env, worldLoader);
-  });
+  }));
 
-  app.post("/auth/login", async (req, res) => {
+  app.post("/auth/login", route(async (req, res) => {
     await loginHandler(req, res, repository, env, worldLoader);
-  });
+  }));
 
-  app.get("/player/me", authMiddleware(env), async (req: AuthenticatedRequest, res) => {
+  app.get("/player/me", authMiddleware(env), route(async (req: AuthenticatedRequest, res) => {
     const username = req.auth!.username;
     const account = await repository.findByUsername(username);
     if (!account) {
-      res.status(404).json({ success: false, message: "플레이어를 찾을 수 없습니다." });
-      return;
+      throw createRouteError(404, "not_found", "플레이어를 찾을 수 없습니다.");
     }
 
     const world = await worldLoader();
     const player = migrateLegacyPlayerSave(account.player as Record<string, unknown> | null, username, world);
-    res.json({ success: true, player });
-  });
+    const payload: PlayerPayload = { player };
+    sendSuccess(res, payload);
+  }));
 
-  app.post("/player/save", authMiddleware(env), async (req: AuthenticatedRequest, res) => {
+  app.post("/player/save", authMiddleware(env), route(async (req: AuthenticatedRequest, res) => {
     const account = await repository.findByUsername(req.auth!.username);
     if (!account) {
-      res.status(404).json({ success: false, message: "플레이어를 찾을 수 없습니다." });
-      return;
+      throw createRouteError(404, "not_found", "플레이어를 찾을 수 없습니다.");
     }
 
-    const player = req.body?.player as PlayerSave | undefined;
-    if (!player || !assertPlayerOwnership(req, player)) {
-      res.status(403).json({ success: false, message: "다른 플레이어의 세이브를 저장할 수 없습니다." });
-      return;
+    const player = readPlayerSave(req.body) as PlayerSave;
+    if (!assertPlayerOwnership(req, player)) {
+      throw createRouteError(403, "forbidden", "다른 플레이어의 세이브를 저장할 수 없습니다.");
     }
 
     await repository.saveAccount({
@@ -71,8 +73,9 @@ export async function createAppContext(options: {
       player,
     });
 
-    res.json({ success: true, player });
-  });
+    const payload: PlayerPayload = { player };
+    sendSuccess(res, payload);
+  }));
 
   const httpServer = createServer(app);
   const io = new Server(httpServer, {

--- a/apps/server/src/http/auth.ts
+++ b/apps/server/src/http/auth.ts
@@ -1,10 +1,12 @@
 import bcrypt from "bcryptjs";
 import jwt, { type SignOptions } from "jsonwebtoken";
 import type { Request, Response, NextFunction } from "express";
-import type { PlayerSave, WorldContent } from "@rpg/game-core";
+import type { PlayerSave, SessionPayload, WorldContent } from "@rpg/game-core";
 import { createStarterPlayer, migrateLegacyPlayerSave } from "@rpg/game-core";
 import type { ServerEnv } from "../config/env";
 import type { UserRepository } from "../storage";
+import { createRouteError, sendFailure, sendSuccess } from "./response";
+import { readCredentials } from "./validation";
 
 type AuthPayload = {
   username: string;
@@ -43,23 +45,11 @@ export async function registerHandler(
   env: ServerEnv,
   worldLoader: () => Promise<WorldContent>,
 ): Promise<void> {
-  const username = String(req.body?.username ?? "").trim();
-  const password = String(req.body?.password ?? "");
-
-  if (username.length < 2) {
-    res.status(400).json({ success: false, message: "사용자 이름은 2자 이상이어야 합니다." });
-    return;
-  }
-
-  if (password.length < 8) {
-    res.status(400).json({ success: false, message: "비밀번호는 최소 8자 이상이어야 합니다." });
-    return;
-  }
+  const { username, password } = readCredentials(req.body);
 
   const existing = await repository.findByUsername(username);
   if (existing) {
-    res.status(409).json({ success: false, message: "이미 존재하는 사용자입니다." });
-    return;
+    throw createRouteError(409, "conflict", "이미 존재하는 사용자입니다.");
   }
 
   const world = await worldLoader();
@@ -71,11 +61,12 @@ export async function registerHandler(
     player,
   });
 
-  res.status(201).json({
-    success: true,
+  const payload: SessionPayload = {
     token: signToken(env, username),
     player,
-  });
+  };
+
+  sendSuccess(res, payload, 201);
 }
 
 export async function loginHandler(
@@ -85,13 +76,11 @@ export async function loginHandler(
   env: ServerEnv,
   worldLoader: () => Promise<WorldContent>,
 ): Promise<void> {
-  const username = String(req.body?.username ?? "").trim();
-  const password = String(req.body?.password ?? "");
+  const { username, password } = readCredentials(req.body);
 
   const account = await repository.findByUsername(username);
   if (!account) {
-    res.status(401).json({ success: false, message: "아이디 또는 비밀번호가 올바르지 않습니다." });
-    return;
+    throw createRouteError(401, "unauthorized", "아이디 또는 비밀번호가 올바르지 않습니다.");
   }
 
   let authenticated = false;
@@ -102,8 +91,7 @@ export async function loginHandler(
   }
 
   if (!authenticated) {
-    res.status(401).json({ success: false, message: "아이디 또는 비밀번호가 올바르지 않습니다." });
-    return;
+    throw createRouteError(401, "unauthorized", "아이디 또는 비밀번호가 올바르지 않습니다.");
   }
 
   const world = await worldLoader();
@@ -117,11 +105,12 @@ export async function loginHandler(
     player: migratedPlayer,
   });
 
-  res.json({
-    success: true,
+  const payload: SessionPayload = {
     token: signToken(env, username),
     player: migratedPlayer,
-  });
+  };
+
+  sendSuccess(res, payload);
 }
 
 export type AuthenticatedRequest = Request & {
@@ -133,7 +122,7 @@ export function authMiddleware(env: ServerEnv) {
     const header = req.headers.authorization;
     const token = header?.startsWith("Bearer ") ? header.slice("Bearer ".length) : undefined;
     if (!token) {
-      res.status(401).json({ success: false, message: "인증 토큰이 필요합니다." });
+      sendFailure(res, 401, "unauthorized", "인증 토큰이 필요합니다.");
       return;
     }
 
@@ -141,7 +130,7 @@ export function authMiddleware(env: ServerEnv) {
       req.auth = verifyToken(env, token);
       next();
     } catch {
-      res.status(401).json({ success: false, message: "유효하지 않은 토큰입니다." });
+      sendFailure(res, 401, "unauthorized", "유효하지 않은 토큰입니다.");
     }
   };
 }

--- a/apps/server/src/http/response.ts
+++ b/apps/server/src/http/response.ts
@@ -1,0 +1,67 @@
+import type { NextFunction, Request, RequestHandler, Response } from "express";
+import type { ApiErrorCode, ApiFailure } from "@rpg/game-core";
+
+export class ApiRouteError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly code: ApiErrorCode,
+    message: string,
+    public readonly details?: string[],
+  ) {
+    super(message);
+    this.name = "ApiRouteError";
+  }
+}
+
+export function createRouteError(
+  status: number,
+  code: ApiErrorCode,
+  message: string,
+  details?: string[],
+): ApiRouteError {
+  return new ApiRouteError(status, code, message, details);
+}
+
+export function sendSuccess<T>(res: Response, data: T, status = 200): void {
+  res.status(status).json({
+    success: true,
+    data,
+  });
+}
+
+export function sendFailure(
+  res: Response,
+  status: number,
+  code: ApiErrorCode,
+  message: string,
+  details?: string[],
+): void {
+  const payload: ApiFailure = {
+    success: false,
+    error: {
+      code,
+      message,
+      details,
+    },
+  };
+
+  res.status(status).json(payload);
+}
+
+export function sendRouteError(res: Response, error: unknown): void {
+  if (error instanceof ApiRouteError) {
+    sendFailure(res, error.status, error.code, error.message, error.details);
+    return;
+  }
+
+  console.error(error);
+  sendFailure(res, 500, "internal_error", "서버 처리 중 오류가 발생했습니다.");
+}
+
+export function route(
+  handler: (req: Request, res: Response, next: NextFunction) => Promise<void> | void,
+): RequestHandler {
+  return (req, res, next) => {
+    Promise.resolve(handler(req, res, next)).catch((error) => sendRouteError(res, error));
+  };
+}

--- a/apps/server/src/http/validation.ts
+++ b/apps/server/src/http/validation.ts
@@ -1,0 +1,148 @@
+import type { PlayerSave } from "@rpg/game-core";
+import { createRouteError } from "./response";
+
+type CredentialsInput = {
+  username: string;
+  password: string;
+};
+
+function asRecord(value: unknown, message: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw createRouteError(400, "bad_request", message);
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function expectString(value: unknown, path: string, issues: string[], options?: { minLength?: number }): void {
+  if (typeof value !== "string") {
+    issues.push(`${path} must be a string.`);
+    return;
+  }
+
+  if (options?.minLength && value.trim().length < options.minLength) {
+    issues.push(`${path} must be at least ${options.minLength} characters long.`);
+  }
+}
+
+function expectNumber(value: unknown, path: string, issues: string[]): void {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    issues.push(`${path} must be a finite number.`);
+  }
+}
+
+function expectStringArray(value: unknown, path: string, issues: string[]): void {
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+    issues.push(`${path} must be an array of strings.`);
+  }
+}
+
+function expectBooleanRecord(value: unknown, path: string, issues: string[]): void {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    issues.push(`${path} must be an object of boolean flags.`);
+    return;
+  }
+
+  Object.entries(value as Record<string, unknown>).forEach(([key, entry]) => {
+    if (typeof entry !== "boolean") {
+      issues.push(`${path}.${key} must be a boolean.`);
+    }
+  });
+}
+
+export function readCredentials(body: unknown): CredentialsInput {
+  const record = asRecord(body, "인증 요청 본문이 올바르지 않습니다.");
+  const username = String(record.username ?? "").trim();
+  const password = String(record.password ?? "");
+
+  if (username.length < 2) {
+    throw createRouteError(400, "validation_error", "사용자 이름은 2자 이상이어야 합니다.");
+  }
+
+  if (password.length < 8) {
+    throw createRouteError(400, "validation_error", "비밀번호는 최소 8자 이상이어야 합니다.");
+  }
+
+  return { username, password };
+}
+
+export function readPlayerSave(body: unknown): PlayerSave {
+  const record = asRecord(body, "세이브 요청 본문이 올바르지 않습니다.");
+  const player = record.player;
+  const issues: string[] = [];
+
+  if (!player || typeof player !== "object" || Array.isArray(player)) {
+    throw createRouteError(400, "bad_request", "세이브 요청에는 player 객체가 필요합니다.");
+  }
+
+  const candidate = player as Record<string, unknown>;
+  const position = candidate.position;
+  const storyState = candidate.storyState;
+  const flags = candidate.flags;
+
+  if (candidate.version !== 2) {
+    issues.push("player.version must be 2.");
+  }
+
+  expectString(candidate.username, "player.username", issues, { minLength: 1 });
+  expectNumber(candidate.coins, "player.coins", issues);
+  expectNumber(candidate.experience, "player.experience", issues);
+  expectNumber(candidate.level, "player.level", issues);
+  expectNumber(candidate.currentHp, "player.currentHp", issues);
+  expectNumber(candidate.currentMp, "player.currentMp", issues);
+  expectNumber(candidate.attack, "player.attack", issues);
+  expectNumber(candidate.defense, "player.defense", issues);
+  expectNumber(candidate.speed, "player.speed", issues);
+  expectNumber(candidate.accuracy, "player.accuracy", issues);
+  expectString(candidate.locationKey, "player.locationKey", issues, { minLength: 1 });
+
+  if (!position || typeof position !== "object" || Array.isArray(position)) {
+    issues.push("player.position must be an object with x and y.");
+  } else {
+    expectNumber((position as Record<string, unknown>).x, "player.position.x", issues);
+    expectNumber((position as Record<string, unknown>).y, "player.position.y", issues);
+  }
+
+  if (!["up", "down", "left", "right"].includes(String(candidate.facing ?? ""))) {
+    issues.push("player.facing must be one of: up, down, left, right.");
+  }
+
+  expectStringArray(candidate.visitedMainLocations, "player.visitedMainLocations", issues);
+  expectStringArray(candidate.visitedLocationKeys, "player.visitedLocationKeys", issues);
+  expectStringArray(candidate.ownedEquipmentIds, "player.ownedEquipmentIds", issues);
+  expectStringArray(candidate.equippedEquipmentIds, "player.equippedEquipmentIds", issues);
+  expectStringArray(candidate.learnedSkillIds, "player.learnedSkillIds", issues);
+  expectStringArray(candidate.learnedTacticIds, "player.learnedTacticIds", issues);
+  expectBooleanRecord(candidate.questCompletion, "player.questCompletion", issues);
+
+  if (!storyState || typeof storyState !== "object" || Array.isArray(storyState)) {
+    issues.push("player.storyState must be an object.");
+  } else {
+    Object.entries(storyState as Record<string, unknown>).forEach(([key, entry]) => {
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+        issues.push(`player.storyState.${key} must be an object.`);
+        return;
+      }
+
+      const state = entry as Record<string, unknown>;
+      if (typeof state.completed !== "boolean") {
+        issues.push(`player.storyState.${key}.completed must be a boolean.`);
+      }
+      if (typeof state.currentIndex !== "number" || !Number.isFinite(state.currentIndex)) {
+        issues.push(`player.storyState.${key}.currentIndex must be a finite number.`);
+      }
+    });
+  }
+
+  if (!flags || typeof flags !== "object" || Array.isArray(flags)) {
+    issues.push("player.flags must be an object.");
+  } else if (typeof (flags as Record<string, unknown>).demonLordDefeated !== "boolean") {
+    issues.push("player.flags.demonLordDefeated must be a boolean.");
+  }
+
+  if (issues.length > 0) {
+    throw createRouteError(400, "validation_error", "플레이어 세이브 형식이 올바르지 않습니다.", issues);
+  }
+
+  return player as PlayerSave;
+}

--- a/apps/server/test/api.test.ts
+++ b/apps/server/test/api.test.ts
@@ -1,6 +1,6 @@
 import request from "supertest";
 import { describe, expect, it } from "vitest";
-import type { WorldContent } from "@rpg/game-core";
+import type { ApiResponse, BootstrapPayload, PlayerPayload, SessionPayload, WorldContent } from "@rpg/game-core";
 import { createStarterPlayer } from "@rpg/game-core";
 import { createAppContext } from "../src/app";
 import { MemoryUserRepository } from "../src/storage/memoryRepository";
@@ -46,15 +46,38 @@ describe("http api", () => {
       .send({ username: "hero", password: "secret123" })
       .expect(201);
 
-    const token = register.body.token as string;
+    const registerPayload = register.body as ApiResponse<SessionPayload>;
+    expect(registerPayload.success).toBe(true);
+    if (!registerPayload.success) {
+      throw new Error("register response should be successful");
+    }
+
+    const token = registerPayload.data.token;
     expect(token).toBeTruthy();
+
+    const bootstrap = await agent
+      .get("/content/bootstrap")
+      .expect(200);
+
+    const bootstrapPayload = bootstrap.body as ApiResponse<BootstrapPayload>;
+    expect(bootstrapPayload.success).toBe(true);
+    if (!bootstrapPayload.success) {
+      throw new Error("bootstrap response should be successful");
+    }
+    expect(bootstrapPayload.data.world.startLocationKey).toBe(world.startLocationKey);
 
     const me = await agent
       .get("/player/me")
       .set("Authorization", `Bearer ${token}`)
       .expect(200);
 
-    expect(me.body.player.username).toBe("hero");
+    const mePayload = me.body as ApiResponse<PlayerPayload>;
+    expect(mePayload.success).toBe(true);
+    if (!mePayload.success) {
+      throw new Error("player/me response should be successful");
+    }
+
+    expect(mePayload.data.player.username).toBe("hero");
 
     const updated = {
       ...createStarterPlayer("hero", world),
@@ -67,7 +90,13 @@ describe("http api", () => {
       .send({ player: updated })
       .expect(200);
 
-    expect(saved.body.player.coins).toBe(123);
+    const savedPayload = saved.body as ApiResponse<PlayerPayload>;
+    expect(savedPayload.success).toBe(true);
+    if (!savedPayload.success) {
+      throw new Error("player/save response should be successful");
+    }
+
+    expect(savedPayload.data.player.coins).toBe(123);
   });
 
   it("hashes passwords on register and upgrades legacy passwords on login", async () => {
@@ -104,5 +133,52 @@ describe("http api", () => {
     const upgraded = await repository.findByUsername("legacy-hero");
     expect(upgraded?.passwordHash).toMatch(/^\$2[aby]\$/);
     expect(upgraded?.passwordHash).not.toBe("secret123");
+  });
+
+  it("returns consistent validation errors for malformed requests", async () => {
+    const repository = new MemoryUserRepository();
+    const world = createWorld();
+    const context = await createAppContext({
+      env: createEnv(),
+      repository,
+      worldLoader: async () => world,
+    });
+
+    const agent = request(context.app);
+
+    const invalidRegister = await agent
+      .post("/auth/register")
+      .send({ username: "a", password: "123" })
+      .expect(400);
+
+    expect(invalidRegister.body).toMatchObject({
+      success: false,
+      error: {
+        code: "validation_error",
+      },
+    });
+
+    const register = await agent
+      .post("/auth/register")
+      .send({ username: "hero", password: "secret123" })
+      .expect(201);
+
+    const registerPayload = register.body as ApiResponse<SessionPayload>;
+    if (!registerPayload.success) {
+      throw new Error("register response should be successful");
+    }
+
+    const malformedSave = await agent
+      .post("/player/save")
+      .set("Authorization", `Bearer ${registerPayload.data.token}`)
+      .send({ player: { username: "hero" } })
+      .expect(400);
+
+    expect(malformedSave.body).toMatchObject({
+      success: false,
+      error: {
+        code: "validation_error",
+      },
+    });
   });
 });

--- a/apps/web/src/net/api.ts
+++ b/apps/web/src/net/api.ts
@@ -1,15 +1,18 @@
-import type { PlayerSave, WorldContent } from "@rpg/game-core";
+import type {
+  ApiResponse,
+  BootstrapPayload,
+  PlayerPayload,
+  PlayerSave,
+  SessionPayload,
+  WorldContent,
+} from "@rpg/game-core";
 
 export class ApiClient {
   constructor(private readonly baseUrl: string) {}
 
   async bootstrap(): Promise<WorldContent> {
-    const response = await fetch(`${this.baseUrl}/content/bootstrap`);
-    const payload = await response.json();
-    if (!response.ok) {
-      throw new Error(payload.message ?? "콘텐츠를 불러오지 못했습니다.");
-    }
-    return payload.world as WorldContent;
+    const payload = await this.readResponse<BootstrapPayload>(`${this.baseUrl}/content/bootstrap`);
+    return payload.world;
   }
 
   async register(username: string, password: string): Promise<{ token: string; player: PlayerSave }> {
@@ -21,20 +24,16 @@ export class ApiClient {
   }
 
   async me(token: string): Promise<PlayerSave> {
-    const response = await fetch(`${this.baseUrl}/player/me`, {
+    const payload = await this.readResponse<PlayerPayload>(`${this.baseUrl}/player/me`, {
       headers: {
         Authorization: `Bearer ${token}`,
       },
     });
-    const payload = await response.json();
-    if (!response.ok) {
-      throw new Error(payload.message ?? "세션이 만료되었습니다.");
-    }
-    return payload.player as PlayerSave;
+    return payload.player;
   }
 
   async save(token: string, player: PlayerSave): Promise<PlayerSave> {
-    const response = await fetch(`${this.baseUrl}/player/save`, {
+    const payload = await this.readResponse<PlayerPayload>(`${this.baseUrl}/player/save`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -42,28 +41,32 @@ export class ApiClient {
       },
       body: JSON.stringify({ player }),
     });
-    const payload = await response.json();
-    if (!response.ok) {
-      throw new Error(payload.message ?? "세이브에 실패했습니다.");
-    }
-    return payload.player as PlayerSave;
+    return payload.player;
   }
 
   private async postAuth(path: string, body: Record<string, unknown>): Promise<{ token: string; player: PlayerSave }> {
-    const response = await fetch(`${this.baseUrl}${path}`, {
+    const payload = await this.readResponse<SessionPayload>(`${this.baseUrl}${path}`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
       body: JSON.stringify(body),
     });
-    const payload = await response.json();
-    if (!response.ok) {
-      throw new Error(payload.message ?? "인증 요청에 실패했습니다.");
-    }
     return {
-      token: payload.token as string,
-      player: payload.player as PlayerSave,
+      token: payload.token,
+      player: payload.player,
     };
+  }
+
+  private async readResponse<T>(input: string, init?: RequestInit): Promise<T> {
+    const response = await fetch(input, init);
+    const payload = await response.json() as ApiResponse<T>;
+
+    if (!response.ok || !payload.success) {
+      const message = payload.success ? "요청 처리에 실패했습니다." : payload.error.message;
+      throw new Error(message);
+    }
+
+    return payload.data;
   }
 }

--- a/packages/game-core/src/contracts.ts
+++ b/packages/game-core/src/contracts.ts
@@ -1,0 +1,45 @@
+import type { PlayerSave, WorldContent } from "./types";
+
+export type ApiErrorCode =
+  | "bad_request"
+  | "validation_error"
+  | "unauthorized"
+  | "forbidden"
+  | "not_found"
+  | "conflict"
+  | "internal_error";
+
+export type ApiErrorPayload = {
+  code: ApiErrorCode;
+  message: string;
+  details?: string[];
+};
+
+export type ApiSuccess<T> = {
+  success: true;
+  data: T;
+};
+
+export type ApiFailure = {
+  success: false;
+  error: ApiErrorPayload;
+};
+
+export type ApiResponse<T> = ApiSuccess<T> | ApiFailure;
+
+export type HealthPayload = {
+  status: "ok";
+};
+
+export type BootstrapPayload = {
+  world: WorldContent;
+};
+
+export type PlayerPayload = {
+  player: PlayerSave;
+};
+
+export type SessionPayload = {
+  token: string;
+  player: PlayerSave;
+};

--- a/packages/game-core/src/index.ts
+++ b/packages/game-core/src/index.ts
@@ -4,3 +4,4 @@ export * from "./engine/player";
 export * from "./engine/battle";
 export * from "./content/legacy";
 export * from "./validation";
+export * from "./contracts";


### PR DESCRIPTION
## 연결 이슈
- Closes #6

## 작업 내용
- 서버 응답을 success/data 와 success/error 형태로 표준화
- 인증 및 저장 요청 검증 로직을 서버 공통 레이어로 분리
- game-core 에 API 계약 타입을 추가해 서버와 웹이 같은 응답 타입을 사용하도록 정리
- 웹 API 클라이언트를 새 계약에 맞게 갱신
- 통합 테스트에 잘못된 인증 및 저장 요청 검증 케이스 추가

## 검증
- corepack pnpm --filter @rpg/server typecheck
- corepack pnpm --filter @rpg/server test
- corepack pnpm --filter @rpg/server build
- corepack pnpm --filter @rpg/server lint
- corepack pnpm --filter @rpg/web typecheck
- corepack pnpm --filter @rpg/web build
- corepack pnpm --filter @rpg/web lint
- corepack pnpm --filter @rpg/game-core typecheck
- corepack pnpm --filter @rpg/game-core test
- corepack pnpm --filter @rpg/game-core build
- corepack pnpm --filter @rpg/game-core lint

## 메모
- 웹 빌드는 현재도 번들 크기 경고가 남아 있지만 이번 계약 정리와는 별개의 기존 상태입니다.