### PR TITLE
feat: 맵 메타데이터와 플레이스홀더 에셋 파이프라인 정리

### DIFF
--- a/apps/web/public/assets/placeholders/actors/encounter.svg
+++ b/apps/web/public/assets/placeholders/actors/encounter.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <polygon points="16,3 29,28 3,28" fill="#e76f51" stroke="#772e25" stroke-width="2"/>
+  <path d="M16 10v8M16 22v1" stroke="#fff7ec" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/apps/web/public/assets/placeholders/actors/npc-guide.svg
+++ b/apps/web/public/assets/placeholders/actors/npc-guide.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <circle cx="12" cy="7" r="4" fill="#f1d2b6"/>
+  <path d="M6 22v-5c0-3.3 2.7-6 6-6s6 2.7 6 6v5" fill="#e9c46a"/>
+  <circle cx="12" cy="14" r="1.5" fill="#1f2933"/>
+</svg>

--- a/apps/web/public/assets/placeholders/actors/player-local.svg
+++ b/apps/web/public/assets/placeholders/actors/player-local.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <circle cx="12" cy="7" r="4" fill="#f4c095"/>
+  <path d="M6 22v-5c0-3.3 2.7-6 6-6s6 2.7 6 6v5" fill="#e76f51"/>
+  <path d="M7 17h10" stroke="#1f2933" stroke-width="2"/>
+</svg>

--- a/apps/web/public/assets/placeholders/actors/player-remote.svg
+++ b/apps/web/public/assets/placeholders/actors/player-remote.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <circle cx="12" cy="7" r="4" fill="#f4c095"/>
+  <path d="M6 22v-5c0-3.3 2.7-6 6-6s6 2.7 6 6v5" fill="#2a9d8f"/>
+  <path d="M7 17h10" stroke="#16322d" stroke-width="2"/>
+</svg>

--- a/apps/web/public/assets/placeholders/actors/portal.svg
+++ b/apps/web/public/assets/placeholders/actors/portal.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28">
+  <path d="M6 24V12c0-4.4 3.6-8 8-8s8 3.6 8 8v12" fill="#264653"/>
+  <path d="M10 24V12c0-2.2 1.8-4 4-4s4 1.8 4 4v12" fill="#7cc3e4"/>
+  <path d="M6 24h16" stroke="#fefae0" stroke-width="2"/>
+</svg>

--- a/apps/web/public/assets/placeholders/props/prop-block.svg
+++ b/apps/web/public/assets/placeholders/props/prop-block.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect x="3" y="3" width="26" height="26" rx="5" fill="#f4d35e" stroke="#1f2933" stroke-width="2"/>
+  <path d="M8 10h16M8 16h16M8 22h16" stroke="#1f2933" stroke-width="2"/>
+</svg>

--- a/apps/web/public/assets/placeholders/terrain/castle.svg
+++ b/apps/web/public/assets/placeholders/terrain/castle.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#4e3f46"/>
+  <path d="M0 12h16M0 8h16" stroke="#7a6570" stroke-width="1"/>
+  <rect x="3" y="3" width="2" height="3" fill="#b08ea0"/>
+  <rect x="11" y="3" width="2" height="3" fill="#b08ea0"/>
+</svg>

--- a/apps/web/public/assets/placeholders/terrain/desert.svg
+++ b/apps/web/public/assets/placeholders/terrain/desert.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#d6b06d"/>
+  <path d="M0 11c3-2 5-2 8 0s5 2 8 0" stroke="#c3924f" stroke-width="1.2" fill="none"/>
+  <circle cx="5" cy="5" r="1" fill="#efd59b"/>
+  <circle cx="12" cy="8" r="1" fill="#efd59b"/>
+</svg>

--- a/apps/web/public/assets/placeholders/terrain/forest.svg
+++ b/apps/web/public/assets/placeholders/terrain/forest.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#4e7d46"/>
+  <circle cx="4" cy="5" r="2" fill="#6da05f"/>
+  <circle cx="12" cy="4" r="2" fill="#7fb86d"/>
+  <rect x="3.5" y="7" width="1" height="4" fill="#3d2a1f"/>
+  <rect x="11.5" y="6" width="1" height="4" fill="#3d2a1f"/>
+</svg>

--- a/apps/web/public/assets/placeholders/terrain/grassland.svg
+++ b/apps/web/public/assets/placeholders/terrain/grassland.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#7dae58"/>
+  <path d="M2 14l1-4 2 4M8 15l1-5 1 3 1-3 1 5" stroke="#4f7c36" stroke-width="1" fill="none"/>
+  <circle cx="12" cy="4" r="1.2" fill="#a8d080"/>
+</svg>

--- a/apps/web/public/assets/placeholders/terrain/mountain.svg
+++ b/apps/web/public/assets/placeholders/terrain/mountain.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#7d8794"/>
+  <path d="M1 13l4-7 4 7M7 13l3-5 5 5" fill="#596473"/>
+  <path d="M4.5 7.5l1-1.8 1.1 1.8" stroke="#dbe4ef" stroke-width="1" fill="none"/>
+</svg>

--- a/apps/web/public/assets/placeholders/terrain/river.svg
+++ b/apps/web/public/assets/placeholders/terrain/river.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#4c89a8"/>
+  <path d="M0 5c3 2 5 2 8 0s5-2 8 0M0 11c3 2 5 2 8 0s5-2 8 0" stroke="#9fd0e6" stroke-width="1" fill="none"/>
+</svg>

--- a/apps/web/public/assets/placeholders/terrain/sea.svg
+++ b/apps/web/public/assets/placeholders/terrain/sea.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#2f6f9c"/>
+  <path d="M0 4h16M0 9h16M0 14h16" stroke="#7cc3e4" stroke-width="1"/>
+  <circle cx="4" cy="6" r="1" fill="#d6f2ff"/>
+</svg>

--- a/apps/web/public/assets/placeholders/terrain/sky.svg
+++ b/apps/web/public/assets/placeholders/terrain/sky.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#88b7e8"/>
+  <path d="M2 11c1.5-2 4.5-2 6 0h4c1 0 2 .8 2 1.8S13 15 12 15H4c-1.7 0-3-1.3-3-3s1.3-3 3-3h1" fill="#eef8ff"/>
+</svg>

--- a/apps/web/public/assets/placeholders/terrain/space.svg
+++ b/apps/web/public/assets/placeholders/terrain/space.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#271f46"/>
+  <circle cx="3" cy="4" r="1" fill="#f4f1ff"/>
+  <circle cx="12" cy="6" r="1" fill="#f4f1ff"/>
+  <circle cx="8" cy="12" r="1.2" fill="#8f7ee8"/>
+  <path d="M0 15l6-3 10 3" stroke="#3f3568" stroke-width="1" fill="none"/>
+</svg>

--- a/apps/web/public/assets/placeholders/terrain/swamp.svg
+++ b/apps/web/public/assets/placeholders/terrain/swamp.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#5f7041"/>
+  <path d="M0 10c2 2 4 2 6 0s4-2 6 0 2 2 4 0" stroke="#364628" stroke-width="1.1" fill="none"/>
+  <circle cx="5" cy="5" r="1.2" fill="#8a9b5b"/>
+  <circle cx="11" cy="12" r="1.2" fill="#8a9b5b"/>
+</svg>

--- a/apps/web/public/assets/placeholders/terrain/village.svg
+++ b/apps/web/public/assets/placeholders/terrain/village.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#d6c3a5"/>
+  <path d="M0 12h16M0 4h16" stroke="#c2aa89" stroke-width="1"/>
+  <path d="M4 0v16M12 0v16" stroke="#eadcc9" stroke-width="1"/>
+</svg>

--- a/apps/web/public/maps/layouts/boss_arena.json
+++ b/apps/web/public/maps/layouts/boss_arena.json
@@ -1,0 +1,41 @@
+{
+  "type": "map",
+  "version": "1.10",
+  "tiledversion": "1.11.0",
+  "orientation": "orthogonal",
+  "renderorder": "right-down",
+  "width": 64,
+  "height": 48,
+  "tilewidth": 16,
+  "tileheight": 16,
+  "infinite": false,
+  "nextlayerid": 3,
+  "nextobjectid": 7,
+  "properties": [
+    { "name": "layoutId", "type": "string", "value": "boss_arena" },
+    { "name": "placeholder", "type": "bool", "value": true }
+  ],
+  "layers": [
+    {
+      "id": 1,
+      "name": "paths",
+      "type": "objectgroup",
+      "objects": [
+        { "id": 1, "name": "arena-ring", "class": "ritual", "x": 296, "y": 236, "width": 432, "height": 236 },
+        { "id": 2, "name": "entry-lane", "class": "road", "x": 456, "y": 472, "width": 112, "height": 216 }
+      ]
+    },
+    {
+      "id": 2,
+      "name": "props",
+      "type": "objectgroup",
+      "objects": [
+        { "id": 3, "name": "pillar-nw", "class": "rock", "x": 194, "y": 146, "width": 70, "height": 70 },
+        { "id": 4, "name": "pillar-ne", "class": "rock", "x": 760, "y": 146, "width": 70, "height": 70 },
+        { "id": 5, "name": "pillar-sw", "class": "rock", "x": 194, "y": 518, "width": 70, "height": 70 },
+        { "id": 6, "name": "pillar-se", "class": "rock", "x": 760, "y": 518, "width": 70, "height": 70, "properties": [{ "name": "label", "type": "string", "value": "boss" }] }
+      ]
+    }
+  ],
+  "tilesets": []
+}

--- a/apps/web/public/maps/layouts/field.json
+++ b/apps/web/public/maps/layouts/field.json
@@ -1,0 +1,41 @@
+{
+  "type": "map",
+  "version": "1.10",
+  "tiledversion": "1.11.0",
+  "orientation": "orthogonal",
+  "renderorder": "right-down",
+  "width": 64,
+  "height": 48,
+  "tilewidth": 16,
+  "tileheight": 16,
+  "infinite": false,
+  "nextlayerid": 3,
+  "nextobjectid": 7,
+  "properties": [
+    { "name": "layoutId", "type": "string", "value": "field" },
+    { "name": "placeholder", "type": "bool", "value": true }
+  ],
+  "layers": [
+    {
+      "id": 1,
+      "name": "paths",
+      "type": "objectgroup",
+      "objects": [
+        { "id": 1, "name": "trail-main", "class": "road", "x": 428, "y": 48, "width": 168, "height": 656 },
+        { "id": 2, "name": "stream-band", "class": "water", "x": 224, "y": 468, "width": 576, "height": 60 }
+      ]
+    },
+    {
+      "id": 2,
+      "name": "props",
+      "type": "objectgroup",
+      "objects": [
+        { "id": 3, "name": "tree-west", "class": "tree", "x": 128, "y": 170, "width": 138, "height": 180 },
+        { "id": 4, "name": "tree-east", "class": "tree", "x": 758, "y": 150, "width": 138, "height": 196 },
+        { "id": 5, "name": "stone-bank", "class": "rock", "x": 424, "y": 540, "width": 188, "height": 54 },
+        { "id": 6, "name": "camp", "class": "stall", "x": 478, "y": 120, "width": 72, "height": 52, "properties": [{ "name": "label", "type": "string", "value": "camp" }] }
+      ]
+    }
+  ],
+  "tilesets": []
+}

--- a/apps/web/public/maps/layouts/inn.json
+++ b/apps/web/public/maps/layouts/inn.json
@@ -1,0 +1,41 @@
+{
+  "type": "map",
+  "version": "1.10",
+  "tiledversion": "1.11.0",
+  "orientation": "orthogonal",
+  "renderorder": "right-down",
+  "width": 64,
+  "height": 48,
+  "tilewidth": 16,
+  "tileheight": 16,
+  "infinite": false,
+  "nextlayerid": 3,
+  "nextobjectid": 7,
+  "properties": [
+    { "name": "layoutId", "type": "string", "value": "inn" },
+    { "name": "placeholder", "type": "bool", "value": true }
+  ],
+  "layers": [
+    {
+      "id": 1,
+      "name": "paths",
+      "type": "objectgroup",
+      "objects": [
+        { "id": 1, "name": "entry-rug", "class": "road", "x": 456, "y": 320, "width": 112, "height": 352 },
+        { "id": 2, "name": "hall", "class": "road", "x": 232, "y": 238, "width": 560, "height": 88 }
+      ]
+    },
+    {
+      "id": 2,
+      "name": "props",
+      "type": "objectgroup",
+      "objects": [
+        { "id": 3, "name": "desk", "class": "stall", "x": 336, "y": 150, "width": 352, "height": 46, "properties": [{ "name": "label", "type": "string", "value": "rest" }] },
+        { "id": 4, "name": "bed-left", "class": "bed", "x": 152, "y": 302, "width": 208, "height": 90 },
+        { "id": 5, "name": "bed-right", "class": "bed", "x": 664, "y": 302, "width": 208, "height": 90 },
+        { "id": 6, "name": "lamp", "class": "altar", "x": 480, "y": 102, "width": 64, "height": 64, "properties": [{ "name": "alpha", "type": "float", "value": 0.64 }] }
+      ]
+    }
+  ],
+  "tilesets": []
+}

--- a/apps/web/public/maps/layouts/plaza.json
+++ b/apps/web/public/maps/layouts/plaza.json
@@ -1,0 +1,41 @@
+{
+  "type": "map",
+  "version": "1.10",
+  "tiledversion": "1.11.0",
+  "orientation": "orthogonal",
+  "renderorder": "right-down",
+  "width": 64,
+  "height": 48,
+  "tilewidth": 16,
+  "tileheight": 16,
+  "infinite": false,
+  "nextlayerid": 3,
+  "nextobjectid": 7,
+  "properties": [
+    { "name": "layoutId", "type": "string", "value": "plaza" },
+    { "name": "placeholder", "type": "bool", "value": true }
+  ],
+  "layers": [
+    {
+      "id": 1,
+      "name": "paths",
+      "type": "objectgroup",
+      "objects": [
+        { "id": 1, "name": "north-south", "class": "road", "x": 448, "y": 48, "width": 128, "height": 656 },
+        { "id": 2, "name": "east-west", "class": "road", "x": 168, "y": 304, "width": 688, "height": 96 }
+      ]
+    },
+    {
+      "id": 2,
+      "name": "props",
+      "type": "objectgroup",
+      "objects": [
+        { "id": 3, "name": "fountain", "class": "altar", "x": 432, "y": 280, "width": 160, "height": 112, "properties": [{ "name": "label", "type": "string", "value": "square" }] },
+        { "id": 4, "name": "market-left", "class": "stall", "x": 140, "y": 156, "width": 132, "height": 84 },
+        { "id": 5, "name": "market-right", "class": "stall", "x": 752, "y": 156, "width": 132, "height": 84 },
+        { "id": 6, "name": "banner", "class": "building", "x": 462, "y": 110, "width": 100, "height": 56, "properties": [{ "name": "alpha", "type": "float", "value": 0.72 }] }
+      ]
+    }
+  ],
+  "tilesets": []
+}

--- a/apps/web/public/maps/layouts/shop.json
+++ b/apps/web/public/maps/layouts/shop.json
@@ -1,0 +1,41 @@
+{
+  "type": "map",
+  "version": "1.10",
+  "tiledversion": "1.11.0",
+  "orientation": "orthogonal",
+  "renderorder": "right-down",
+  "width": 64,
+  "height": 48,
+  "tilewidth": 16,
+  "tileheight": 16,
+  "infinite": false,
+  "nextlayerid": 3,
+  "nextobjectid": 7,
+  "properties": [
+    { "name": "layoutId", "type": "string", "value": "shop" },
+    { "name": "placeholder", "type": "bool", "value": true }
+  ],
+  "layers": [
+    {
+      "id": 1,
+      "name": "paths",
+      "type": "objectgroup",
+      "objects": [
+        { "id": 1, "name": "entry-rug", "class": "road", "x": 456, "y": 320, "width": 112, "height": 352 },
+        { "id": 2, "name": "service-lane", "class": "road", "x": 248, "y": 240, "width": 528, "height": 96 }
+      ]
+    },
+    {
+      "id": 2,
+      "name": "props",
+      "type": "objectgroup",
+      "objects": [
+        { "id": 3, "name": "counter", "class": "stall", "x": 320, "y": 154, "width": 384, "height": 48, "properties": [{ "name": "label", "type": "string", "value": "forge" }] },
+        { "id": 4, "name": "rack-left", "class": "rock", "x": 128, "y": 138, "width": 72, "height": 188 },
+        { "id": 5, "name": "rack-right", "class": "rock", "x": 824, "y": 138, "width": 72, "height": 188 },
+        { "id": 6, "name": "anvil", "class": "building", "x": 444, "y": 100, "width": 136, "height": 42, "properties": [{ "name": "alpha", "type": "float", "value": 0.7 }] }
+      ]
+    }
+  ],
+  "tilesets": []
+}

--- a/apps/web/public/maps/layouts/skill_shop.json
+++ b/apps/web/public/maps/layouts/skill_shop.json
@@ -1,0 +1,41 @@
+{
+  "type": "map",
+  "version": "1.10",
+  "tiledversion": "1.11.0",
+  "orientation": "orthogonal",
+  "renderorder": "right-down",
+  "width": 64,
+  "height": 48,
+  "tilewidth": 16,
+  "tileheight": 16,
+  "infinite": false,
+  "nextlayerid": 3,
+  "nextobjectid": 7,
+  "properties": [
+    { "name": "layoutId", "type": "string", "value": "skill_shop" },
+    { "name": "placeholder", "type": "bool", "value": true }
+  ],
+  "layers": [
+    {
+      "id": 1,
+      "name": "paths",
+      "type": "objectgroup",
+      "objects": [
+        { "id": 1, "name": "focus-lane", "class": "ritual", "x": 436, "y": 96, "width": 152, "height": 592 },
+        { "id": 2, "name": "study-ring", "class": "road", "x": 312, "y": 228, "width": 400, "height": 128 }
+      ]
+    },
+    {
+      "id": 2,
+      "name": "props",
+      "type": "objectgroup",
+      "objects": [
+        { "id": 3, "name": "altar", "class": "altar", "x": 420, "y": 150, "width": 184, "height": 64, "properties": [{ "name": "label", "type": "string", "value": "focus" }] },
+        { "id": 4, "name": "archive-left", "class": "building", "x": 128, "y": 136, "width": 82, "height": 198 },
+        { "id": 5, "name": "archive-right", "class": "building", "x": 814, "y": 136, "width": 82, "height": 198 },
+        { "id": 6, "name": "sigil", "class": "altar", "x": 462, "y": 270, "width": 100, "height": 100, "properties": [{ "name": "alpha", "type": "float", "value": 0.72 }] }
+      ]
+    }
+  ],
+  "tilesets": []
+}

--- a/apps/web/public/maps/layouts/town_gate.json
+++ b/apps/web/public/maps/layouts/town_gate.json
@@ -1,0 +1,41 @@
+{
+  "type": "map",
+  "version": "1.10",
+  "tiledversion": "1.11.0",
+  "orientation": "orthogonal",
+  "renderorder": "right-down",
+  "width": 64,
+  "height": 48,
+  "tilewidth": 16,
+  "tileheight": 16,
+  "infinite": false,
+  "nextlayerid": 3,
+  "nextobjectid": 7,
+  "properties": [
+    { "name": "layoutId", "type": "string", "value": "town_gate" },
+    { "name": "placeholder", "type": "bool", "value": true }
+  ],
+  "layers": [
+    {
+      "id": 1,
+      "name": "paths",
+      "type": "objectgroup",
+      "objects": [
+        { "id": 1, "name": "main-road", "class": "road", "x": 432, "y": 48, "width": 160, "height": 656 },
+        { "id": 2, "name": "cross-road", "class": "road", "x": 176, "y": 288, "width": 672, "height": 112 }
+      ]
+    },
+    {
+      "id": 2,
+      "name": "props",
+      "type": "objectgroup",
+      "objects": [
+        { "id": 3, "name": "west-house", "class": "building", "x": 112, "y": 96, "width": 192, "height": 160, "properties": [{ "name": "label", "type": "string", "value": "west" }] },
+        { "id": 4, "name": "east-house", "class": "building", "x": 720, "y": 96, "width": 192, "height": 160, "properties": [{ "name": "label", "type": "string", "value": "east" }] },
+        { "id": 5, "name": "planter", "class": "tree", "x": 448, "y": 320, "width": 128, "height": 80, "properties": [{ "name": "alpha", "type": "float", "value": 0.76 }] },
+        { "id": 6, "name": "notice", "class": "stall", "x": 468, "y": 120, "width": 88, "height": 48, "properties": [{ "name": "label", "type": "string", "value": "gate" }] }
+      ]
+    }
+  ],
+  "tilesets": []
+}

--- a/apps/web/src/game/BootScene.ts
+++ b/apps/web/src/game/BootScene.ts
@@ -1,38 +1,23 @@
 import Phaser from "phaser";
+import { getSceneAssetManifest } from "@rpg/game-core";
 
 export class BootScene extends Phaser.Scene {
   constructor() {
     super("boot");
   }
 
+  preload(): void {
+    const manifest = getSceneAssetManifest();
+    manifest.jsonPaths.forEach((path) => {
+      this.load.json(path, path);
+    });
+
+    manifest.texturePaths.forEach((path) => {
+      this.load.svg(path, path);
+    });
+  }
+
   create(): void {
-    const graphics = this.add.graphics();
-
-    graphics.fillStyle(0xf3efe0, 1);
-    graphics.fillRect(0, 0, 16, 16);
-    graphics.generateTexture("tile-floor", 16, 16);
-
-    graphics.clear();
-    graphics.fillStyle(0xe76f51, 1);
-    graphics.fillRect(0, 0, 16, 16);
-    graphics.generateTexture("player-local", 16, 16);
-
-    graphics.clear();
-    graphics.fillStyle(0x2a9d8f, 1);
-    graphics.fillRect(0, 0, 16, 16);
-    graphics.generateTexture("player-remote", 16, 16);
-
-    graphics.clear();
-    graphics.fillStyle(0xe9c46a, 1);
-    graphics.fillRect(0, 0, 20, 20);
-    graphics.generateTexture("npc-guide", 20, 20);
-
-    graphics.clear();
-    graphics.fillStyle(0x264653, 1);
-    graphics.fillRect(0, 0, 28, 28);
-    graphics.generateTexture("portal", 28, 28);
-
-    graphics.destroy();
     this.scene.start("overworld");
   }
 }

--- a/apps/web/src/game/OverworldScene.ts
+++ b/apps/web/src/game/OverworldScene.ts
@@ -1,5 +1,13 @@
 import Phaser from "phaser";
-import type { DialogueNpc, EncounterZone, Facing, PlayerSave, PresenceState, SceneDefinition, WorldContent } from "@rpg/game-core";
+import type {
+  DialogueNpc,
+  EncounterZone,
+  Facing,
+  PlayerSave,
+  PresenceState,
+  SceneDefinition,
+  WorldContent,
+} from "@rpg/game-core";
 
 type SceneCallbacks = {
   canMove: () => boolean;
@@ -7,6 +15,32 @@ type SceneCallbacks = {
   onSceneChange: (locationKey: string) => void;
   onInteractNpc: (npc: DialogueNpc) => void;
   onEncounter: (zone: EncounterZone) => void;
+};
+
+type TiledProperty = {
+  name: string;
+  value: string | number | boolean;
+};
+
+type TiledObject = {
+  id: number;
+  name: string;
+  class?: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  properties?: TiledProperty[];
+};
+
+type TiledObjectLayer = {
+  name: string;
+  type: "objectgroup";
+  objects: TiledObject[];
+};
+
+type TiledMapData = {
+  layers: TiledObjectLayer[];
 };
 
 export class OverworldScene extends Phaser.Scene {
@@ -18,6 +52,7 @@ export class OverworldScene extends Phaser.Scene {
   private remoteSprites = new Map<string, Phaser.GameObjects.Container>();
   private portals: Array<{ zone: Phaser.Geom.Rectangle; locationKey: string; label: string }> = [];
   private encounterZones: Array<{ zone: Phaser.Geom.Rectangle; data: EncounterZone }> = [];
+  private collisionZones: Phaser.Geom.Rectangle[] = [];
   private npcMarkers: Array<{ sprite: Phaser.GameObjects.Sprite; npc: DialogueNpc }> = [];
   private cursorKeys!: Phaser.Types.Input.Keyboard.CursorKeys;
   private keyW!: Phaser.Input.Keyboard.Key;
@@ -43,16 +78,6 @@ export class OverworldScene extends Phaser.Scene {
     this.keyEnter = this.input.keyboard!.addKey("ENTER");
     this.keySpace = this.input.keyboard!.addKey("SPACE");
     this.keyBattle = this.input.keyboard!.addKey("B");
-
-    this.playerSprite = this.add.sprite(512, 384, "player-local").setDisplaySize(26, 26);
-    this.hintText = this.add
-      .text(20, 20, "", {
-        color: "#f3efe0",
-        fontFamily: "IBM Plex Sans KR, Pretendard, sans-serif",
-        fontSize: "18px",
-      })
-      .setScrollFactor(0)
-      .setDepth(10);
 
     if (this.world && this.playerState) {
       this.buildLocation();
@@ -94,7 +119,14 @@ export class OverworldScene extends Phaser.Scene {
           return;
         }
 
-        const sprite = this.add.sprite(0, 0, "player-remote").setDisplaySize(22, 22);
+        const remoteTexturePath = this.sceneDefinition?.assets.remotePlayerTexturePath;
+        if (!remoteTexturePath) {
+          return;
+        }
+
+        const sprite = this.add
+          .sprite(0, 0, remoteTexturePath)
+          .setDisplaySize(22, 22);
         const label = this.add.text(0, -18, presence.username, {
           color: "#fefae0",
           fontFamily: "Space Mono, monospace",
@@ -113,7 +145,7 @@ export class OverworldScene extends Phaser.Scene {
   }
 
   update(time: number, delta: number): void {
-    if (!this.playerState || !this.callbacks || !this.sceneDefinition) {
+    if (!this.playerState || !this.callbacks || !this.sceneDefinition || !this.playerSprite || !this.hintText) {
       return;
     }
 
@@ -140,8 +172,11 @@ export class OverworldScene extends Phaser.Scene {
     }
 
     const distance = speed * (delta / 1000);
-    const nextX = Phaser.Math.Clamp(this.playerSprite.x + velocityX * distance, 36, this.sceneDefinition.width - 36);
-    const nextY = Phaser.Math.Clamp(this.playerSprite.y + velocityY * distance, 36, this.sceneDefinition.height - 36);
+    const desiredX = Phaser.Math.Clamp(this.playerSprite.x + velocityX * distance, 36, this.sceneDefinition.width - 36);
+    const desiredY = Phaser.Math.Clamp(this.playerSprite.y + velocityY * distance, 36, this.sceneDefinition.height - 36);
+    const nextX = this.isBlocked(desiredX, this.playerSprite.y) ? this.playerSprite.x : desiredX;
+    const nextY = this.isBlocked(nextX, desiredY) ? this.playerSprite.y : desiredY;
+
     this.playerSprite.setPosition(nextX, nextY);
     this.playerState = {
       ...this.playerState,
@@ -199,33 +234,41 @@ export class OverworldScene extends Phaser.Scene {
     this.children.removeAll(true);
     this.portals = [];
     this.encounterZones = [];
+    this.collisionZones = [];
     this.npcMarkers = [];
     this.remoteSprites.forEach((sprite) => sprite.destroy());
     this.remoteSprites.clear();
 
-    const floor = this.add.rectangle(
-      location.scene.width / 2,
-      location.scene.height / 2,
-      location.scene.width - 48,
-      location.scene.height - 48,
-      Phaser.Display.Color.HexStringToColor("#f4e7d3").color,
-    );
-    floor.setStrokeStyle(6, Phaser.Display.Color.HexStringToColor("#22333b").color);
+    this.renderSceneMap(location.scene);
+
+    location.scene.collisionZones.forEach((zone) => {
+      const collisionHint = this.add.rectangle(
+        zone.x + zone.width / 2,
+        zone.y + zone.height / 2,
+        zone.width,
+        zone.height,
+        Phaser.Display.Color.HexStringToColor("#182026").color,
+        0.12,
+      ).setDepth(1);
+      collisionHint.setStrokeStyle(1, Phaser.Display.Color.HexStringToColor("#0f1720").color, 0.2);
+      this.collisionZones.push(new Phaser.Geom.Rectangle(zone.x, zone.y, zone.width, zone.height));
+    });
 
     location.scene.portals.forEach((portal) => {
-      this.add.rectangle(
-        portal.x + portal.width / 2,
-        portal.y + portal.height / 2,
-        portal.width,
-        portal.height,
-        Phaser.Display.Color.HexStringToColor("#264653").color,
-      );
+      this.add
+        .image(
+          portal.x + portal.width / 2,
+          portal.y + portal.height / 2,
+          location.scene.assets.portalTexturePath,
+        )
+        .setDisplaySize(Math.max(portal.width, 28), Math.max(portal.height, 28))
+        .setDepth(3);
       this.add.text(portal.x + portal.width / 2, portal.y + portal.height / 2, portal.label, {
         color: "#fefae0",
         fontFamily: "Space Mono, monospace",
         fontSize: "11px",
         align: "center",
-      }).setOrigin(0.5);
+      }).setOrigin(0.5).setDepth(4);
       this.portals.push({
         zone: new Phaser.Geom.Rectangle(portal.x, portal.y, portal.width, portal.height),
         locationKey: portal.toLocationKey,
@@ -234,14 +277,15 @@ export class OverworldScene extends Phaser.Scene {
     });
 
     location.scene.encounterZones.forEach((encounterZone) => {
-      this.add.rectangle(
-        encounterZone.x + encounterZone.width / 2,
-        encounterZone.y + encounterZone.height / 2,
-        encounterZone.width,
-        encounterZone.height,
-        Phaser.Display.Color.HexStringToColor("#e76f51").color,
-        0.18,
-      );
+      this.add
+        .image(
+          encounterZone.x + encounterZone.width / 2,
+          encounterZone.y + encounterZone.height / 2,
+          location.scene.assets.encounterTexturePath,
+        )
+        .setDisplaySize(encounterZone.width, encounterZone.height)
+        .setAlpha(0.22)
+        .setDepth(2);
       this.encounterZones.push({
         zone: new Phaser.Geom.Rectangle(encounterZone.x, encounterZone.y, encounterZone.width, encounterZone.height),
         data: encounterZone,
@@ -249,16 +293,22 @@ export class OverworldScene extends Phaser.Scene {
     });
 
     location.scene.npcs.forEach((npc) => {
-      const sprite = this.add.sprite(npc.x, npc.y, "npc-guide").setDisplaySize(24, 24);
+      const sprite = this.add
+        .sprite(npc.x, npc.y, location.scene.assets.npcTexturePath)
+        .setDisplaySize(24, 24)
+        .setDepth(6);
       this.add.text(npc.x, npc.y - 22, npc.name, {
         color: "#111827",
         fontFamily: "IBM Plex Sans KR, Pretendard, sans-serif",
         fontSize: "12px",
-      }).setOrigin(0.5, 1);
+      }).setOrigin(0.5, 1).setDepth(7);
       this.npcMarkers.push({ sprite, npc });
     });
 
-    this.playerSprite = this.add.sprite(this.playerState.position.x, this.playerState.position.y, "player-local").setDisplaySize(26, 26).setDepth(6);
+    this.playerSprite = this.add
+      .sprite(this.playerState.position.x, this.playerState.position.y, location.scene.assets.playerTexturePath)
+      .setDisplaySize(26, 26)
+      .setDepth(8);
     this.hintText = this.add
       .text(20, 20, "", {
         color: "#f3efe0",
@@ -266,8 +316,109 @@ export class OverworldScene extends Phaser.Scene {
         fontSize: "18px",
       })
       .setScrollFactor(0)
-      .setDepth(10);
+      .setDepth(20);
 
     this.cameras.main.setBounds(0, 0, location.scene.width, location.scene.height);
+  }
+
+  private renderSceneMap(scene: SceneDefinition): void {
+    this.add
+      .tileSprite(scene.width / 2, scene.height / 2, scene.width, scene.height, scene.assets.terrainTexturePath)
+      .setDepth(0);
+
+    const mapData = this.cache.json.get(scene.assets.mapJsonPath) as TiledMapData | undefined;
+    if (!mapData) {
+      return;
+    }
+
+    mapData.layers
+      .filter((layer) => layer.type === "objectgroup")
+      .forEach((layer) => {
+        if (layer.name === "paths") {
+          layer.objects.forEach((object) => {
+            this.add.rectangle(
+              object.x + object.width / 2,
+              object.y + object.height / 2,
+              object.width,
+              object.height,
+              this.colorForPath(object.class),
+              0.24,
+            ).setDepth(1);
+          });
+          return;
+        }
+
+        if (layer.name === "props") {
+          layer.objects.forEach((object) => {
+            const prop = this.add
+              .image(
+                object.x + object.width / 2,
+                object.y + object.height / 2,
+                scene.assets.propsTexturePath,
+              )
+              .setDisplaySize(Math.max(object.width, 18), Math.max(object.height, 18))
+              .setTint(this.colorForProp(object.class))
+              .setAlpha(this.readAlpha(object.properties))
+              .setDepth(2);
+
+            const label = this.readLabel(object.properties);
+            if (label) {
+              this.add.text(prop.x, prop.y + object.height / 2 + 6, label, {
+                color: "#f8fafc",
+                fontFamily: "Space Mono, monospace",
+                fontSize: "10px",
+              }).setOrigin(0.5, 0).setDepth(3);
+            }
+          });
+        }
+      });
+  }
+
+  private isBlocked(x: number, y: number): boolean {
+    const size = 20;
+    const hitbox = new Phaser.Geom.Rectangle(x - size / 2, y - size / 2, size, size);
+    return this.collisionZones.some((zone) => Phaser.Geom.Intersects.RectangleToRectangle(hitbox, zone));
+  }
+
+  private colorForPath(kind?: string): number {
+    switch (kind) {
+      case "water":
+        return Phaser.Display.Color.HexStringToColor("#5fa8d3").color;
+      case "road":
+        return Phaser.Display.Color.HexStringToColor("#d4a373").color;
+      case "ritual":
+        return Phaser.Display.Color.HexStringToColor("#9a5de0").color;
+      default:
+        return Phaser.Display.Color.HexStringToColor("#f2cc8f").color;
+    }
+  }
+
+  private colorForProp(kind?: string): number {
+    switch (kind) {
+      case "tree":
+        return Phaser.Display.Color.HexStringToColor("#386641").color;
+      case "rock":
+        return Phaser.Display.Color.HexStringToColor("#6b7280").color;
+      case "stall":
+        return Phaser.Display.Color.HexStringToColor("#b56576").color;
+      case "bed":
+        return Phaser.Display.Color.HexStringToColor("#84a59d").color;
+      case "altar":
+        return Phaser.Display.Color.HexStringToColor("#7b2cbf").color;
+      case "building":
+        return Phaser.Display.Color.HexStringToColor("#8d6e63").color;
+      default:
+        return Phaser.Display.Color.HexStringToColor("#f4d35e").color;
+    }
+  }
+
+  private readAlpha(properties?: TiledProperty[]): number {
+    const value = properties?.find((property) => property.name === "alpha")?.value;
+    return typeof value === "number" ? value : 0.84;
+  }
+
+  private readLabel(properties?: TiledProperty[]): string | null {
+    const value = properties?.find((property) => property.name === "label")?.value;
+    return typeof value === "string" && value.trim() ? value : null;
   }
 }

--- a/apps/web/test/assetPipeline.test.ts
+++ b/apps/web/test/assetPipeline.test.ts
@@ -1,0 +1,59 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { buildWorldContentFromLegacy, getSceneAssetManifest } from "@rpg/game-core";
+import { describe, expect, it } from "vitest";
+import boss from "../../../game/boss.json";
+import equipment from "../../../game/equipment.json";
+import map from "../../../game/map.json";
+import monster from "../../../game/monster.json";
+import skill from "../../../game/skill.json";
+import tactics from "../../../game/tactics.json";
+
+function toPublicPath(assetPath: string): string {
+  return resolve(process.cwd(), "public", assetPath.slice(1));
+}
+
+describe("web asset pipeline", () => {
+  const world = buildWorldContentFromLegacy({
+    map,
+    monsters: monster,
+    bosses: boss,
+    equipment: equipment as never,
+    skills: skill as never,
+    tactics: tactics as never,
+  });
+
+  it("ships every shared map and placeholder asset referenced by scenes", () => {
+    const manifest = getSceneAssetManifest();
+    const scenePaths = new Set<string>([
+      ...manifest.jsonPaths,
+      ...manifest.texturePaths,
+    ]);
+
+    Object.values(world.locations).forEach((location) => {
+      scenePaths.add(location.scene.assets.mapJsonPath);
+      scenePaths.add(location.scene.assets.terrainTexturePath);
+      scenePaths.add(location.scene.assets.propsTexturePath);
+      scenePaths.add(location.scene.assets.playerTexturePath);
+      scenePaths.add(location.scene.assets.remotePlayerTexturePath);
+      scenePaths.add(location.scene.assets.npcTexturePath);
+      scenePaths.add(location.scene.assets.portalTexturePath);
+      scenePaths.add(location.scene.assets.encounterTexturePath);
+    });
+
+    Array.from(scenePaths).forEach((assetPath) => {
+      expect(existsSync(toPublicPath(assetPath)), `${assetPath} should exist in apps/web/public`).toBe(true);
+    });
+  });
+
+  it("keeps scene layout metadata aligned with the tiled placeholder maps", () => {
+    Object.values(world.locations).forEach((location) => {
+      const source = readFileSync(toPublicPath(location.scene.assets.mapJsonPath), "utf8");
+      const mapJson = JSON.parse(source) as {
+        properties?: Array<{ name: string; value: string | boolean }>;
+      };
+      const layoutProperty = mapJson.properties?.find((property) => property.name === "layoutId");
+      expect(layoutProperty?.value).toBe(location.scene.assets.layoutId);
+    });
+  });
+});

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": ".",
-    "types": ["vite/client"]
+    "types": ["vite/client", "node", "vitest/globals"]
   },
-  "include": ["src", "vite.config.ts"]
+  "include": ["src", "test", "vite.config.ts"]
 }

--- a/docs/asset-pipeline.md
+++ b/docs/asset-pipeline.md
@@ -1,0 +1,38 @@
+# Map Metadata And Placeholder Asset Pipeline
+
+## Goals
+- Keep location-to-scene metadata in `game-core` so server and client use the same 2D scene contract.
+- Store placeholder art and Tiled-compatible JSON maps under `apps/web/public` so the browser can load them without build-time coupling.
+- Catch missing maps, bad scene links, and broken asset conventions in automated tests.
+
+## Path Rules
+- Layout maps: `/maps/layouts/<layout-id>.json`
+- Terrain textures: `/assets/placeholders/terrain/<theme-id>.svg`
+- Shared prop texture: `/assets/placeholders/props/prop-block.svg`
+- Shared actor textures:
+  - `/assets/placeholders/actors/player-local.svg`
+  - `/assets/placeholders/actors/player-remote.svg`
+  - `/assets/placeholders/actors/npc-guide.svg`
+  - `/assets/placeholders/actors/portal.svg`
+  - `/assets/placeholders/actors/encounter.svg`
+
+## Scene Metadata Contract
+- `scene.themeId`: biome-level terrain variant
+- `scene.tileSize`: base tile scale for Tiled layouts
+- `scene.assets.layoutId`: shared layout template id
+- `scene.assets.mapJsonPath`: public Tiled JSON path
+- `scene.collisionZones`: runtime movement blockers
+- `scene.portals`, `scene.npcs`, `scene.encounterZones`: location-specific interactive objects
+
+## Current Layout Templates
+- `town_gate`
+- `shop`
+- `inn`
+- `skill_shop`
+- `plaza`
+- `field`
+- `boss_arena`
+
+## Validation
+- `packages/game-core/src/validation.ts` checks layout/theme conventions, bounds, collisions, and location links.
+- `apps/web/test/assetPipeline.test.ts` verifies that every declared public asset exists and that each map JSON advertises the same `layoutId` as the scene metadata.

--- a/packages/game-core/src/content/legacy.ts
+++ b/packages/game-core/src/content/legacy.ts
@@ -12,6 +12,12 @@ import type {
   TacticDefinition,
   WorldContent,
 } from "../types";
+import {
+  createSceneLayout,
+  getSceneAssetBundle,
+  getSceneLayoutId,
+  getSceneThemeId,
+} from "./sceneMetadata";
 import { toLocationKey, toStableId } from "../utils/id";
 import { assertValidWorldContent } from "../validation";
 
@@ -312,25 +318,32 @@ function areaColor(mainLocation: string): string {
   return colors[mainLocation] ?? "#34506b";
 }
 
-function buildScene(mainLocation: string, subLocation: string, story: string[], enemyIds: string[], connectionKeys: Array<{ label: string; toLocationKey: string }>) {
+function buildScene(
+  mainLocation: string,
+  subLocation: string,
+  story: string[],
+  enemyIds: string[],
+  connectionKeys: Array<{ label: string; toLocationKey: string }>,
+  hasBoss: boolean,
+) {
   const sceneId = toStableId("scene", `${mainLocation}-${subLocation}`);
-  const width = 1024;
-  const height = 768;
-  const portalSlots = [
-    { x: width / 2 - 50, y: 12, width: 100, height: 24 },
-    { x: width - 36, y: height / 2 - 50, width: 24, height: 100 },
-    { x: width / 2 - 50, y: height - 36, width: 100, height: 24 },
-    { x: 12, y: height / 2 - 50, width: 24, height: 100 },
-  ];
+  const themeId = getSceneThemeId(mainLocation);
+  const layoutId = getSceneLayoutId(subLocation, {
+    hasEncounter: enemyIds.length > 0,
+    hasBoss,
+  });
+  const layout = createSceneLayout(layoutId);
 
   return {
     sceneId,
-    width,
-    height,
+    themeId,
+    width: layout.width,
+    height: layout.height,
+    tileSize: layout.tileSize,
     backgroundColor: areaColor(mainLocation),
-    spawn: { x: width / 2, y: height - 120 },
+    spawn: { ...layout.spawn },
     portals: connectionKeys.map((connection, index) => {
-      const slot = portalSlots[index % portalSlots.length]!;
+      const slot = layout.portalSlots[index % layout.portalSlots.length]!;
       return {
         id: toStableId("portal", `${sceneId}-${connection.toLocationKey}`),
         label: connection.label,
@@ -343,8 +356,8 @@ function buildScene(mainLocation: string, subLocation: string, story: string[], 
           {
             id: toStableId("npc", `${sceneId}-guide`),
             name: `${subLocation} 안내자`,
-            x: width / 2,
-            y: 160,
+            x: layout.npcAnchor.x,
+            y: layout.npcAnchor.y,
             lines: story,
           },
         ]
@@ -353,14 +366,22 @@ function buildScene(mainLocation: string, subLocation: string, story: string[], 
       ? [
           {
             id: toStableId("encounter", sceneId),
-            x: width / 2 - 180,
-            y: height / 2,
-            width: 360,
-            height: 180,
+            x: layout.encounterZone.x,
+            y: layout.encounterZone.y,
+            width: layout.encounterZone.width,
+            height: layout.encounterZone.height,
             enemyIds,
           },
         ]
       : [],
+    collisionZones: layout.collisionZones.map((zone) => ({
+      id: toStableId("collision", `${sceneId}-${zone.id}`),
+      x: zone.x,
+      y: zone.y,
+      width: zone.width,
+      height: zone.height,
+    })),
+    assets: getSceneAssetBundle(themeId, layoutId),
   };
 }
 
@@ -542,6 +563,7 @@ export function buildWorldContentFromLegacy(input: {
             label: connection.sub,
             toLocationKey: connection.toLocationKey,
           })),
+          Boolean(location.보스),
         ),
       };
     });

--- a/packages/game-core/src/content/sceneMetadata.ts
+++ b/packages/game-core/src/content/sceneMetadata.ts
@@ -1,0 +1,300 @@
+import type { CollisionZone, SceneAssetBundle, SceneLayoutId, SceneThemeId } from "../types";
+
+type SceneRect = {
+  id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+type SceneLayoutTemplate = {
+  width: number;
+  height: number;
+  tileSize: number;
+  spawn: { x: number; y: number };
+  npcAnchor: { x: number; y: number };
+  encounterZone: { x: number; y: number; width: number; height: number };
+  portalSlots: Array<{ x: number; y: number; width: number; height: number }>;
+  collisionZones: SceneRect[];
+};
+
+export const SCENE_THEME_IDS: SceneThemeId[] = [
+  "village",
+  "grassland",
+  "forest",
+  "desert",
+  "mountain",
+  "swamp",
+  "river",
+  "sea",
+  "sky",
+  "space",
+  "castle",
+];
+
+export const SCENE_LAYOUT_IDS: SceneLayoutId[] = [
+  "town_gate",
+  "shop",
+  "inn",
+  "skill_shop",
+  "plaza",
+  "field",
+  "boss_arena",
+];
+
+const COMMON_TEXTURES = {
+  propsTexturePath: "/assets/placeholders/props/prop-block.svg",
+  playerTexturePath: "/assets/placeholders/actors/player-local.svg",
+  remotePlayerTexturePath: "/assets/placeholders/actors/player-remote.svg",
+  npcTexturePath: "/assets/placeholders/actors/npc-guide.svg",
+  portalTexturePath: "/assets/placeholders/actors/portal.svg",
+  encounterTexturePath: "/assets/placeholders/actors/encounter.svg",
+} as const;
+
+const SCENE_LAYOUTS: Record<SceneLayoutId, SceneLayoutTemplate> = {
+  town_gate: {
+    width: 1024,
+    height: 768,
+    tileSize: 16,
+    spawn: { x: 512, y: 636 },
+    npcAnchor: { x: 512, y: 188 },
+    encounterZone: { x: 372, y: 346, width: 280, height: 136 },
+    portalSlots: [
+      { x: 468, y: 22, width: 88, height: 24 },
+      { x: 942, y: 324, width: 24, height: 120 },
+      { x: 468, y: 722, width: 88, height: 24 },
+      { x: 58, y: 324, width: 24, height: 120 },
+    ],
+    collisionZones: [
+      { id: "north-left-block", x: 96, y: 96, width: 240, height: 164 },
+      { id: "north-right-block", x: 688, y: 96, width: 240, height: 164 },
+      { id: "center-planter", x: 432, y: 304, width: 160, height: 88 },
+    ],
+  },
+  shop: {
+    width: 1024,
+    height: 768,
+    tileSize: 16,
+    spawn: { x: 512, y: 640 },
+    npcAnchor: { x: 512, y: 180 },
+    encounterZone: { x: 404, y: 392, width: 216, height: 116 },
+    portalSlots: [
+      { x: 468, y: 718, width: 88, height: 24 },
+      { x: 468, y: 22, width: 88, height: 24 },
+      { x: 942, y: 324, width: 24, height: 120 },
+      { x: 58, y: 324, width: 24, height: 120 },
+    ],
+    collisionZones: [
+      { id: "counter", x: 248, y: 150, width: 528, height: 68 },
+      { id: "rack-left", x: 110, y: 110, width: 108, height: 240 },
+      { id: "rack-right", x: 806, y: 110, width: 108, height: 240 },
+    ],
+  },
+  inn: {
+    width: 1024,
+    height: 768,
+    tileSize: 16,
+    spawn: { x: 512, y: 640 },
+    npcAnchor: { x: 512, y: 190 },
+    encounterZone: { x: 404, y: 392, width: 216, height: 116 },
+    portalSlots: [
+      { x: 468, y: 718, width: 88, height: 24 },
+      { x: 468, y: 22, width: 88, height: 24 },
+      { x: 942, y: 324, width: 24, height: 120 },
+      { x: 58, y: 324, width: 24, height: 120 },
+    ],
+    collisionZones: [
+      { id: "reception", x: 272, y: 142, width: 480, height: 58 },
+      { id: "bed-left", x: 138, y: 288, width: 236, height: 120 },
+      { id: "bed-right", x: 650, y: 288, width: 236, height: 120 },
+    ],
+  },
+  skill_shop: {
+    width: 1024,
+    height: 768,
+    tileSize: 16,
+    spawn: { x: 512, y: 640 },
+    npcAnchor: { x: 512, y: 186 },
+    encounterZone: { x: 404, y: 392, width: 216, height: 116 },
+    portalSlots: [
+      { x: 468, y: 718, width: 88, height: 24 },
+      { x: 468, y: 22, width: 88, height: 24 },
+      { x: 942, y: 324, width: 24, height: 120 },
+      { x: 58, y: 324, width: 24, height: 120 },
+    ],
+    collisionZones: [
+      { id: "altar", x: 404, y: 146, width: 216, height: 78 },
+      { id: "archive-left", x: 120, y: 120, width: 110, height: 244 },
+      { id: "archive-right", x: 794, y: 120, width: 110, height: 244 },
+    ],
+  },
+  plaza: {
+    width: 1024,
+    height: 768,
+    tileSize: 16,
+    spawn: { x: 512, y: 630 },
+    npcAnchor: { x: 512, y: 174 },
+    encounterZone: { x: 356, y: 392, width: 312, height: 124 },
+    portalSlots: [
+      { x: 468, y: 22, width: 88, height: 24 },
+      { x: 942, y: 324, width: 24, height: 120 },
+      { x: 468, y: 722, width: 88, height: 24 },
+      { x: 58, y: 324, width: 24, height: 120 },
+    ],
+    collisionZones: [
+      { id: "fountain", x: 404, y: 260, width: 216, height: 152 },
+      { id: "market-left", x: 122, y: 138, width: 154, height: 104 },
+      { id: "market-right", x: 748, y: 138, width: 154, height: 104 },
+    ],
+  },
+  field: {
+    width: 1024,
+    height: 768,
+    tileSize: 16,
+    spawn: { x: 512, y: 646 },
+    npcAnchor: { x: 512, y: 168 },
+    encounterZone: { x: 312, y: 304, width: 400, height: 182 },
+    portalSlots: [
+      { x: 468, y: 22, width: 88, height: 24 },
+      { x: 942, y: 324, width: 24, height: 120 },
+      { x: 468, y: 722, width: 88, height: 24 },
+      { x: 58, y: 324, width: 24, height: 120 },
+    ],
+    collisionZones: [
+      { id: "tree-cluster-left", x: 108, y: 148, width: 172, height: 208 },
+      { id: "tree-cluster-right", x: 744, y: 128, width: 172, height: 224 },
+      { id: "rock-bank", x: 404, y: 520, width: 224, height: 84 },
+    ],
+  },
+  boss_arena: {
+    width: 1024,
+    height: 768,
+    tileSize: 16,
+    spawn: { x: 512, y: 640 },
+    npcAnchor: { x: 512, y: 152 },
+    encounterZone: { x: 296, y: 236, width: 432, height: 236 },
+    portalSlots: [
+      { x: 468, y: 718, width: 88, height: 24 },
+      { x: 468, y: 22, width: 88, height: 24 },
+      { x: 942, y: 324, width: 24, height: 120 },
+      { x: 58, y: 324, width: 24, height: 120 },
+    ],
+    collisionZones: [
+      { id: "pillar-nw", x: 178, y: 134, width: 94, height: 94 },
+      { id: "pillar-ne", x: 752, y: 134, width: 94, height: 94 },
+      { id: "pillar-sw", x: 178, y: 506, width: 94, height: 94 },
+      { id: "pillar-se", x: 752, y: 506, width: 94, height: 94 },
+    ],
+  },
+};
+
+function cloneZones(zones: SceneRect[]): CollisionZone[] {
+  return zones.map((zone) => ({ ...zone }));
+}
+
+export function getSceneThemeId(mainLocation: string): SceneThemeId {
+  const explicit: Record<string, SceneThemeId> = {
+    "시작의 마을": "village",
+    "시작의 땅": "grassland",
+    "평화의 마을": "village",
+    "이웃 마을": "village",
+    사막: "desert",
+    산길: "mountain",
+    늪지: "swamp",
+    하천: "river",
+    바다: "sea",
+    하늘: "sky",
+    우주: "space",
+    "마왕의 성": "castle",
+  };
+
+  return explicit[mainLocation] ?? "grassland";
+}
+
+export function getSceneLayoutId(
+  subLocation: string,
+  options: { hasEncounter: boolean; hasBoss: boolean },
+): SceneLayoutId {
+  if (subLocation === "무기 상점") {
+    return "shop";
+  }
+
+  if (subLocation === "여관") {
+    return "inn";
+  }
+
+  if (subLocation === "기술 상점") {
+    return "skill_shop";
+  }
+
+  if (subLocation.includes("광장")) {
+    return "plaza";
+  }
+
+  if (subLocation === "마을 입구") {
+    return "town_gate";
+  }
+
+  if (options.hasBoss) {
+    return "boss_arena";
+  }
+
+  if (options.hasEncounter) {
+    return "field";
+  }
+
+  return "field";
+}
+
+export function createSceneLayout(layoutId: SceneLayoutId): SceneLayoutTemplate {
+  const template = SCENE_LAYOUTS[layoutId];
+  return {
+    width: template.width,
+    height: template.height,
+    tileSize: template.tileSize,
+    spawn: { ...template.spawn },
+    npcAnchor: { ...template.npcAnchor },
+    encounterZone: { ...template.encounterZone },
+    portalSlots: template.portalSlots.map((slot) => ({ ...slot })),
+    collisionZones: cloneZones(template.collisionZones),
+  };
+}
+
+export function getSceneMapJsonPath(layoutId: SceneLayoutId): string {
+  return `/maps/layouts/${layoutId}.json`;
+}
+
+export function getSceneTerrainTexturePath(themeId: SceneThemeId): string {
+  return `/assets/placeholders/terrain/${themeId}.svg`;
+}
+
+export function getSceneAssetBundle(themeId: SceneThemeId, layoutId: SceneLayoutId): SceneAssetBundle {
+  return {
+    layoutId,
+    mapJsonPath: getSceneMapJsonPath(layoutId),
+    terrainTexturePath: getSceneTerrainTexturePath(themeId),
+    propsTexturePath: COMMON_TEXTURES.propsTexturePath,
+    playerTexturePath: COMMON_TEXTURES.playerTexturePath,
+    remotePlayerTexturePath: COMMON_TEXTURES.remotePlayerTexturePath,
+    npcTexturePath: COMMON_TEXTURES.npcTexturePath,
+    portalTexturePath: COMMON_TEXTURES.portalTexturePath,
+    encounterTexturePath: COMMON_TEXTURES.encounterTexturePath,
+    license: "placeholder",
+    attribution: "Handmade SVG placeholder assets for development-only map prototyping.",
+  };
+}
+
+export function getCommonSceneTexturePaths(): string[] {
+  return Object.values(COMMON_TEXTURES);
+}
+
+export function getSceneAssetManifest(): { jsonPaths: string[]; texturePaths: string[] } {
+  return {
+    jsonPaths: SCENE_LAYOUT_IDS.map((layoutId) => getSceneMapJsonPath(layoutId)),
+    texturePaths: [
+      ...SCENE_THEME_IDS.map((themeId) => getSceneTerrainTexturePath(themeId)),
+      ...getCommonSceneTexturePaths(),
+    ],
+  };
+}

--- a/packages/game-core/src/index.ts
+++ b/packages/game-core/src/index.ts
@@ -3,5 +3,6 @@ export * from "./utils/id";
 export * from "./engine/player";
 export * from "./engine/battle";
 export * from "./content/legacy";
+export * from "./content/sceneMetadata";
 export * from "./validation";
 export * from "./contracts";

--- a/packages/game-core/src/types.ts
+++ b/packages/game-core/src/types.ts
@@ -92,6 +92,28 @@ export type EnemyDefinition = {
   isBoss?: boolean;
 };
 
+export type SceneThemeId =
+  | "village"
+  | "grassland"
+  | "forest"
+  | "desert"
+  | "mountain"
+  | "swamp"
+  | "river"
+  | "sea"
+  | "sky"
+  | "space"
+  | "castle";
+
+export type SceneLayoutId =
+  | "town_gate"
+  | "shop"
+  | "inn"
+  | "skill_shop"
+  | "plaza"
+  | "field"
+  | "boss_arena";
+
 export type ScenePortal = {
   id: string;
   label: string;
@@ -119,15 +141,41 @@ export type EncounterZone = {
   enemyIds: string[];
 };
 
-export type SceneDefinition = {
-  sceneId: string;
+export type CollisionZone = {
+  id: string;
+  x: number;
+  y: number;
   width: number;
   height: number;
+};
+
+export type SceneAssetBundle = {
+  layoutId: SceneLayoutId;
+  mapJsonPath: string;
+  terrainTexturePath: string;
+  propsTexturePath: string;
+  playerTexturePath: string;
+  remotePlayerTexturePath: string;
+  npcTexturePath: string;
+  portalTexturePath: string;
+  encounterTexturePath: string;
+  license: "placeholder";
+  attribution: string;
+};
+
+export type SceneDefinition = {
+  sceneId: string;
+  themeId: SceneThemeId;
+  width: number;
+  height: number;
+  tileSize: number;
   backgroundColor: string;
   spawn: { x: number; y: number };
   portals: ScenePortal[];
   npcs: DialogueNpc[];
   encounterZones: EncounterZone[];
+  collisionZones: CollisionZone[];
+  assets: SceneAssetBundle;
 };
 
 export type LocationConnection = {

--- a/packages/game-core/src/validation.ts
+++ b/packages/game-core/src/validation.ts
@@ -1,4 +1,5 @@
 import type {
+  CollisionZone,
   EffectDefinition,
   EffectFormula,
   EncounterZone,
@@ -10,6 +11,13 @@ import type {
   TacticDefinition,
   WorldContent,
 } from "./types";
+import {
+  getCommonSceneTexturePaths,
+  getSceneMapJsonPath,
+  getSceneTerrainTexturePath,
+  SCENE_LAYOUT_IDS,
+  SCENE_THEME_IDS,
+} from "./content/sceneMetadata";
 
 export type ValidationIssue = {
   path: string;
@@ -20,6 +28,9 @@ const VALID_EFFECT_TRIGGERS = new Set<EffectDefinition["trigger"]>(["on_use", "o
 const VALID_EFFECT_TARGETS = new Set<EffectDefinition["target"]>(["self", "opponent"]);
 const VALID_FORMULA_SOURCES = new Set<EffectFormula["source"]>(["none", "self_attack", "target_attack"]);
 const VALID_TACTIC_TYPES = new Set<TacticDefinition["type"]>(["charge", "multi", "guard_break", "evade"]);
+const VALID_SCENE_LAYOUTS = new Set(SCENE_LAYOUT_IDS);
+const VALID_SCENE_THEMES = new Set(SCENE_THEME_IDS);
+const VALID_COMMON_SCENE_TEXTURES = new Set(getCommonSceneTexturePaths());
 
 function issue(path: string, message: string): ValidationIssue {
   return { path, message };
@@ -177,8 +188,75 @@ function validateSceneBounds(scene: SceneDefinition, path: string): ValidationIs
     issues.push(issue(`${path}.height`, "Scene height must be greater than 0."));
   }
 
+  if (!Number.isInteger(scene.tileSize) || scene.tileSize <= 0) {
+    issues.push(issue(`${path}.tileSize`, "Scene tileSize must be a positive integer."));
+  }
+
+  if (!VALID_SCENE_THEMES.has(scene.themeId)) {
+    issues.push(issue(`${path}.themeId`, `Unknown scene theme '${String(scene.themeId)}'.`));
+  }
+
   if (scene.spawn.x < 0 || scene.spawn.x > scene.width || scene.spawn.y < 0 || scene.spawn.y > scene.height) {
     issues.push(issue(`${path}.spawn`, "Scene spawn must be inside the scene bounds."));
+  }
+
+  if (!VALID_SCENE_LAYOUTS.has(scene.assets.layoutId)) {
+    issues.push(issue(`${path}.assets.layoutId`, `Unknown scene layout '${String(scene.assets.layoutId)}'.`));
+  }
+
+  if (scene.assets.mapJsonPath !== getSceneMapJsonPath(scene.assets.layoutId)) {
+    issues.push(issue(`${path}.assets.mapJsonPath`, "Scene mapJsonPath does not match the shared layout convention."));
+  }
+
+  if (scene.assets.terrainTexturePath !== getSceneTerrainTexturePath(scene.themeId)) {
+    issues.push(issue(`${path}.assets.terrainTexturePath`, "Scene terrainTexturePath does not match the shared theme convention."));
+  }
+
+  const commonTextureEntries: Array<[string, string]> = [
+    ["propsTexturePath", scene.assets.propsTexturePath],
+    ["playerTexturePath", scene.assets.playerTexturePath],
+    ["remotePlayerTexturePath", scene.assets.remotePlayerTexturePath],
+    ["npcTexturePath", scene.assets.npcTexturePath],
+    ["portalTexturePath", scene.assets.portalTexturePath],
+    ["encounterTexturePath", scene.assets.encounterTexturePath],
+  ];
+
+  commonTextureEntries.forEach(([field, value]) => {
+    if (!VALID_COMMON_SCENE_TEXTURES.has(value)) {
+      issues.push(issue(`${path}.assets.${field}`, "Scene texture path is outside the shared placeholder asset set."));
+    }
+  });
+
+  if (scene.assets.license !== "placeholder") {
+    issues.push(issue(`${path}.assets.license`, "Scene assets must currently be tagged as placeholder."));
+  }
+
+  if (!scene.assets.attribution.trim()) {
+    issues.push(issue(`${path}.assets.attribution`, "Scene assets must include attribution text."));
+  }
+
+  return issues;
+}
+
+function validateRectangleInsideScene(
+  zone: Pick<CollisionZone, "x" | "y" | "width" | "height">,
+  scene: SceneDefinition,
+  path: string,
+  label: string,
+): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+
+  if (!isFiniteNumber(zone.x) || !isFiniteNumber(zone.y) || !isFiniteNumber(zone.width) || !isFiniteNumber(zone.height)) {
+    issues.push(issue(path, `${label} bounds must use finite numbers.`));
+    return issues;
+  }
+
+  if (zone.width <= 0 || zone.height <= 0) {
+    issues.push(issue(path, `${label} bounds must have positive width and height.`));
+  }
+
+  if (zone.x < 0 || zone.y < 0 || zone.x + zone.width > scene.width || zone.y + zone.height > scene.height) {
+    issues.push(issue(path, `${label} bounds must stay inside the scene.`));
   }
 
   return issues;
@@ -217,6 +295,16 @@ function validateLocation(location: LocationNode, key: string, world: WorldConte
 
   issues.push(...validateSceneBounds(location.scene, `${path}.scene`));
 
+  location.scene.portals.forEach((portal, index) => {
+    issues.push(...validateRectangleInsideScene(portal, location.scene, `${path}.scene.portals[${index}]`, "Portal"));
+  });
+
+  location.scene.npcs.forEach((npc, index) => {
+    if (npc.x < 0 || npc.x > location.scene.width || npc.y < 0 || npc.y > location.scene.height) {
+      issues.push(issue(`${path}.scene.npcs[${index}]`, "NPC anchor must stay inside the scene."));
+    }
+  });
+
   location.connections.forEach((connection, index) => {
     if (!world.locations[connection.toLocationKey]) {
       issues.push(issue(`${path}.connections[${index}].toLocationKey`, `Unknown location '${connection.toLocationKey}'.`));
@@ -230,8 +318,29 @@ function validateLocation(location: LocationNode, key: string, world: WorldConte
   });
 
   location.scene.encounterZones.forEach((zone, index) => {
+    issues.push(...validateRectangleInsideScene(zone, location.scene, `${path}.scene.encounterZones[${index}]`, "Encounter zone"));
     issues.push(...validateEncounterZone(zone, world, `${path}.scene.encounterZones[${index}]`));
   });
+
+  const collisionIds = new Set<string>();
+  location.scene.collisionZones.forEach((zone, index) => {
+    issues.push(...validateRectangleInsideScene(zone, location.scene, `${path}.scene.collisionZones[${index}]`, "Collision zone"));
+    if (collisionIds.has(zone.id)) {
+      issues.push(issue(`${path}.scene.collisionZones[${index}].id`, `Duplicate collision zone id '${zone.id}'.`));
+    } else {
+      collisionIds.add(zone.id);
+    }
+  });
+
+  const spawnInsideCollision = location.scene.collisionZones.some((zone) => (
+    location.scene.spawn.x >= zone.x
+    && location.scene.spawn.x <= zone.x + zone.width
+    && location.scene.spawn.y >= zone.y
+    && location.scene.spawn.y <= zone.y + zone.height
+  ));
+  if (spawnInsideCollision) {
+    issues.push(issue(`${path}.scene.spawn`, "Scene spawn cannot overlap a collision zone."));
+  }
 
   return issues;
 }

--- a/packages/game-core/test/content.test.ts
+++ b/packages/game-core/test/content.test.ts
@@ -22,6 +22,8 @@ describe("legacy content conversion", () => {
     expect(Object.keys(world.locations).length).toBeGreaterThan(10);
     expect(world.skills.every((entry) => entry.effects.length > 0)).toBe(true);
     expect(world.equipment.every((entry) => entry.effects.length >= 0)).toBe(true);
+    expect(Object.values(world.locations).every((location) => location.scene.assets.mapJsonPath.endsWith(".json"))).toBe(true);
+    expect(Object.values(world.locations).every((location) => location.scene.collisionZones.length > 0)).toBe(true);
     expect(validateWorldContent(world)).toEqual([]);
   });
 
@@ -46,5 +48,36 @@ describe("legacy content conversion", () => {
 
     expect(issues.some((entry) => entry.path === "startLocationKey")).toBe(true);
     expect(issues.some((entry) => entry.message.includes("enemy-missing"))).toBe(true);
+  });
+
+  it("reports invalid scene asset metadata through validation", () => {
+    const world = buildWorldContentFromLegacy({
+      map,
+      monsters: monster,
+      bosses: boss,
+      equipment: equipment as never,
+      skills: skill as never,
+      tactics: tactics as never,
+    });
+
+    const start = world.locations["시작의 마을::마을 입구"]!;
+    const issues = validateWorldContent({
+      ...world,
+      locations: {
+        ...world.locations,
+        [start.key]: {
+          ...start,
+          scene: {
+            ...start.scene,
+            assets: {
+              ...start.scene.assets,
+              mapJsonPath: "/maps/layouts/missing.json",
+            },
+          },
+        },
+      },
+    });
+
+    expect(issues.some((entry) => entry.path.endsWith("assets.mapJsonPath"))).toBe(true);
   });
 });


### PR DESCRIPTION
## 연결 이슈
- Closes #8

## 작업 내용
- game-core 씬 타입에 theme, layout, collisionZones, asset bundle 메타데이터를 추가
- 레거시 월드 변환 시 location 별 2D 씬 메타데이터와 에셋 경로 규칙을 생성하도록 정리
- apps/web/public 에 Tiled 호환 레이아웃 JSON과 SVG 플레이스홀더 에셋 세트를 추가
- Phaser 부트 단계에서 공용 맵과 에셋을 preload 하고 오버월드에서 scene metadata 기반으로 렌더링하도록 갱신
- 맵 링크 규칙과 public 자산 존재 여부를 검증하는 테스트 및 문서를 추가

## 검증
- corepack pnpm --filter @rpg/game-core typecheck
- corepack pnpm --filter @rpg/game-core test
- corepack pnpm --filter @rpg/game-core lint
- corepack pnpm --filter @rpg/game-core build
- corepack pnpm --filter @rpg/web typecheck
- corepack pnpm --filter @rpg/web test
- corepack pnpm --filter @rpg/web build
- corepack pnpm --filter @rpg/web lint
- corepack pnpm --filter @rpg/server typecheck
- corepack pnpm --filter @rpg/server test
- corepack pnpm --filter @rpg/server build
- corepack pnpm --filter @rpg/server lint

## 메모
- 웹 번들 크기 경고는 기존과 동일하게 남아 있으며, 이번 작업에서는 맵/에셋 파이프라인 정리에 집중했습니다.