### PR TITLE
feat: 오버월드 탐험 MVP 씬 구조와 HUD 개편

### DIFF
--- a/apps/web/src/game/GameBridge.ts
+++ b/apps/web/src/game/GameBridge.ts
@@ -1,6 +1,8 @@
 import Phaser from "phaser";
 import type { DialogueNpc, EncounterZone, Facing, PlayerSave, PresenceState, WorldContent } from "@rpg/game-core";
 import { BootScene } from "./BootScene";
+import { LoadingScene } from "./LoadingScene";
+import { LoginScene } from "./LoginScene";
 import { OverworldScene } from "./OverworldScene";
 
 type BridgeCallbacks = {
@@ -13,7 +15,10 @@ type BridgeCallbacks = {
 
 export class GameBridge {
   private readonly game: Phaser.Game;
+  private readonly loadingScene = new LoadingScene();
+  private readonly loginScene = new LoginScene();
   private readonly overworldScene = new OverworldScene();
+  private activeScene: "loading" | "login" | "overworld" = "loading";
 
   constructor(container: HTMLElement, private readonly callbacks: BridgeCallbacks) {
     this.game = new Phaser.Game({
@@ -22,7 +27,7 @@ export class GameBridge {
       width: 1024,
       height: 768,
       backgroundColor: "#1f2937",
-      scene: [new BootScene(), this.overworldScene],
+      scene: [new BootScene(), this.loadingScene, this.loginScene, this.overworldScene],
       render: {
         pixelArt: true,
       },
@@ -30,15 +35,30 @@ export class GameBridge {
   }
 
   sync(world: WorldContent | null, player: PlayerSave | null, nearbyPlayers: PresenceState[]): void {
-    if (!world || !player) {
+    if (!world) {
+      return;
+    }
+
+    if (!player) {
+      this.ensureScene("login");
       return;
     }
 
     this.overworldScene.attach(world, player, this.callbacks);
     this.overworldScene.sync(player, nearbyPlayers);
+    this.ensureScene("overworld");
   }
 
   destroy(): void {
     this.game.destroy(true);
+  }
+
+  private ensureScene(nextScene: "loading" | "login" | "overworld"): void {
+    if (this.activeScene === nextScene) {
+      return;
+    }
+
+    this.game.scene.start(nextScene);
+    this.activeScene = nextScene;
   }
 }

--- a/apps/web/src/game/LoadingScene.ts
+++ b/apps/web/src/game/LoadingScene.ts
@@ -1,0 +1,38 @@
+import Phaser from "phaser";
+
+export class LoadingScene extends Phaser.Scene {
+  constructor() {
+    super("loading");
+  }
+
+  create(): void {
+    this.cameras.main.setBackgroundColor("#10231b");
+
+    this.add.rectangle(512, 384, 760, 460, Phaser.Display.Color.HexStringToColor("#18392b").color, 0.92)
+      .setStrokeStyle(2, Phaser.Display.Color.HexStringToColor("#d4a373").color, 0.4);
+
+    this.add.text(512, 270, "RPG Rebuild", {
+      color: "#f4efe3",
+      fontFamily: "IBM Plex Sans KR, Pretendard, sans-serif",
+      fontSize: "40px",
+      fontStyle: "700",
+    }).setOrigin(0.5);
+
+    this.add.text(512, 330, "월드 데이터와 플레이스홀더 맵을 불러오는 중", {
+      color: "#d6c6ac",
+      fontFamily: "IBM Plex Sans KR, Pretendard, sans-serif",
+      fontSize: "18px",
+    }).setOrigin(0.5);
+
+    const pulse = this.add.circle(512, 418, 18, Phaser.Display.Color.HexStringToColor("#e9c46a").color, 0.85);
+    this.tweens.add({
+      targets: pulse,
+      scale: 1.45,
+      alpha: 0.28,
+      duration: 900,
+      yoyo: true,
+      repeat: -1,
+      ease: "sine.inOut",
+    });
+  }
+}

--- a/apps/web/src/game/LoginScene.ts
+++ b/apps/web/src/game/LoginScene.ts
@@ -1,0 +1,53 @@
+import Phaser from "phaser";
+
+export class LoginScene extends Phaser.Scene {
+  constructor() {
+    super("login");
+  }
+
+  create(): void {
+    this.cameras.main.setBackgroundColor("#1a2c24");
+
+    const frame = this.add.rectangle(
+      512,
+      384,
+      820,
+      500,
+      Phaser.Display.Color.HexStringToColor("#203a2c").color,
+      0.94,
+    );
+    frame.setStrokeStyle(2, Phaser.Display.Color.HexStringToColor("#f2cc8f").color, 0.35);
+
+    this.add.text(512, 236, "Adventurer Gate", {
+      color: "#f7f2e7",
+      fontFamily: "Space Mono, monospace",
+      fontSize: "18px",
+      letterSpacing: 6,
+    }).setOrigin(0.5);
+
+    this.add.text(512, 314, "탐험을 시작하려면 접속 카드를 작성하세요", {
+      color: "#f5eee1",
+      fontFamily: "IBM Plex Sans KR, Pretendard, sans-serif",
+      fontSize: "34px",
+      fontStyle: "700",
+      align: "center",
+    }).setOrigin(0.5);
+
+    this.add.text(512, 380, "로그인 후에는 맵 이동, 상호작용, 씬 전환이 즉시 오버월드에서 이어집니다.", {
+      color: "#d5cab8",
+      fontFamily: "IBM Plex Sans KR, Pretendard, sans-serif",
+      fontSize: "17px",
+      align: "center",
+      wordWrap: { width: 560 },
+    }).setOrigin(0.5);
+
+    const sigil = this.add.star(512, 470, 6, 24, 56, Phaser.Display.Color.HexStringToColor("#2a9d8f").color, 0.18);
+    this.tweens.add({
+      targets: sigil,
+      angle: 360,
+      duration: 16000,
+      repeat: -1,
+      ease: "linear",
+    });
+  }
+}

--- a/apps/web/src/game/OverworldScene.ts
+++ b/apps/web/src/game/OverworldScene.ts
@@ -255,7 +255,7 @@ export class OverworldScene extends Phaser.Scene {
     });
 
     location.scene.portals.forEach((portal) => {
-      this.add
+      const portalSprite = this.add
         .image(
           portal.x + portal.width / 2,
           portal.y + portal.height / 2,
@@ -263,6 +263,14 @@ export class OverworldScene extends Phaser.Scene {
         )
         .setDisplaySize(Math.max(portal.width, 28), Math.max(portal.height, 28))
         .setDepth(3);
+      this.tweens.add({
+        targets: portalSprite,
+        y: portalSprite.y - 8,
+        duration: 1300,
+        yoyo: true,
+        repeat: -1,
+        ease: "sine.inOut",
+      });
       this.add.text(portal.x + portal.width / 2, portal.y + portal.height / 2, portal.label, {
         color: "#fefae0",
         fontFamily: "Space Mono, monospace",
@@ -277,7 +285,7 @@ export class OverworldScene extends Phaser.Scene {
     });
 
     location.scene.encounterZones.forEach((encounterZone) => {
-      this.add
+      const encounterMarker = this.add
         .image(
           encounterZone.x + encounterZone.width / 2,
           encounterZone.y + encounterZone.height / 2,
@@ -286,6 +294,14 @@ export class OverworldScene extends Phaser.Scene {
         .setDisplaySize(encounterZone.width, encounterZone.height)
         .setAlpha(0.22)
         .setDepth(2);
+      this.tweens.add({
+        targets: encounterMarker,
+        alpha: 0.34,
+        duration: 900,
+        yoyo: true,
+        repeat: -1,
+        ease: "sine.inOut",
+      });
       this.encounterZones.push({
         zone: new Phaser.Geom.Rectangle(encounterZone.x, encounterZone.y, encounterZone.width, encounterZone.height),
         data: encounterZone,
@@ -297,6 +313,14 @@ export class OverworldScene extends Phaser.Scene {
         .sprite(npc.x, npc.y, location.scene.assets.npcTexturePath)
         .setDisplaySize(24, 24)
         .setDepth(6);
+      this.tweens.add({
+        targets: sprite,
+        y: sprite.y - 6,
+        duration: 1100,
+        yoyo: true,
+        repeat: -1,
+        ease: "sine.inOut",
+      });
       this.add.text(npc.x, npc.y - 22, npc.name, {
         color: "#111827",
         fontFamily: "IBM Plex Sans KR, Pretendard, sans-serif",
@@ -319,6 +343,9 @@ export class OverworldScene extends Phaser.Scene {
       .setDepth(20);
 
     this.cameras.main.setBounds(0, 0, location.scene.width, location.scene.height);
+    this.cameras.main.startFollow(this.playerSprite, true, 0.12, 0.12);
+    this.cameras.main.setDeadzone(220, 160);
+    this.cameras.main.roundPixels = true;
   }
 
   private renderSceneMap(scene: SceneDefinition): void {

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -1,11 +1,24 @@
 :root {
+  --bg-deep: #0f1d18;
+  --bg-mid: #183127;
+  --surface: rgba(14, 24, 20, 0.78);
+  --surface-strong: rgba(17, 28, 23, 0.92);
+  --surface-soft: rgba(245, 239, 226, 0.12);
+  --line-soft: rgba(255, 247, 232, 0.14);
+  --line-strong: rgba(242, 204, 143, 0.36);
+  --text-main: #f7f3e8;
+  --text-muted: #d2c7b5;
+  --accent-gold: #f2cc8f;
+  --accent-rust: #d07c47;
+  --accent-mint: #53b59c;
+  --accent-red: #d86d60;
   color-scheme: dark;
   font-family: "IBM Plex Sans KR", "Pretendard", sans-serif;
+  color: var(--text-main);
   background:
-    radial-gradient(circle at top left, rgba(231, 111, 81, 0.28), transparent 28%),
-    radial-gradient(circle at top right, rgba(42, 157, 143, 0.24), transparent 22%),
-    linear-gradient(180deg, #172026 0%, #0f1419 100%);
-  color: #f7f3e9;
+    radial-gradient(circle at top left, rgba(83, 181, 156, 0.22), transparent 30%),
+    radial-gradient(circle at top right, rgba(208, 124, 71, 0.2), transparent 28%),
+    linear-gradient(180deg, #12241d 0%, #09110e 100%);
 }
 
 * {
@@ -23,185 +36,421 @@ input {
   font: inherit;
 }
 
+button {
+  cursor: pointer;
+}
+
 #app {
   min-height: 100vh;
 }
 
-.shell {
-  display: grid;
-  grid-template-columns: 340px 1fr;
+.viewport-shell {
+  position: relative;
   min-height: 100vh;
-  gap: 18px;
+  overflow: hidden;
+}
+
+.atmosphere {
+  position: fixed;
+  inset: auto;
+  pointer-events: none;
+  filter: blur(48px);
+  opacity: 0.7;
+}
+
+.atmosphere-one {
+  width: 340px;
+  height: 340px;
+  left: -90px;
+  top: 40px;
+  border-radius: 50%;
+  background: rgba(83, 181, 156, 0.25);
+}
+
+.atmosphere-two {
+  width: 360px;
+  height: 360px;
+  right: -110px;
+  bottom: 24px;
+  border-radius: 50%;
+  background: rgba(208, 124, 71, 0.22);
+}
+
+.game-stage {
+  position: relative;
+  min-height: 100vh;
   padding: 18px;
 }
 
-.sidebar,
-.stage-wrap {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-.stage-wrap {
-  min-width: 0;
-}
-
-.stage-header {
-  padding: 18px 22px;
-  border-radius: 24px;
-  background: rgba(11, 18, 26, 0.72);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  backdrop-filter: blur(14px);
-}
-
-.stage-header h1 {
-  margin: 0;
-  font-size: 2rem;
-  letter-spacing: 0.02em;
-}
-
-.stage-header p {
-  margin: 6px 0 0;
-  color: #d7cfbf;
+.stage-canvas,
+.ui-layer {
+  position: absolute;
+  inset: 18px;
+  border-radius: 32px;
 }
 
 .stage-canvas {
-  position: relative;
-  border-radius: 28px;
   overflow: hidden;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--line-soft);
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.05), transparent),
-    rgba(9, 14, 20, 0.88);
-  min-height: 768px;
+    linear-gradient(180deg, rgba(255, 255, 255, 0.05), transparent 16%),
+    rgba(6, 10, 8, 0.9);
+  box-shadow:
+    0 28px 80px rgba(0, 0, 0, 0.38),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
 }
 
 .stage-canvas canvas {
   display: block;
-  width: 100%;
-  height: auto;
+  width: 100% !important;
+  height: 100% !important;
+}
+
+.ui-layer {
+  pointer-events: none;
+}
+
+.ui-layer > * {
+  pointer-events: auto;
 }
 
 .panel {
-  border-radius: 22px;
-  background: rgba(11, 18, 26, 0.76);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  padding: 16px;
-  backdrop-filter: blur(12px);
+  border-radius: 24px;
+  background: var(--surface);
+  border: 1px solid var(--line-soft);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.24);
+  backdrop-filter: blur(16px);
 }
 
-.panel.visible {
+.hud-panel {
+  position: absolute;
+  top: 18px;
+  left: 18px;
+  right: 18px;
+  padding: 16px 18px;
+}
+
+.log-panel {
+  position: absolute;
+  top: 154px;
+  right: 18px;
+  width: 320px;
+  padding: 16px;
+}
+
+.chat-panel {
+  position: absolute;
+  right: 18px;
+  bottom: 168px;
+  width: 340px;
+  padding: 16px;
+}
+
+.action-panel {
+  display: none;
+  position: absolute;
+  left: 18px;
+  right: 376px;
+  bottom: 18px;
+  padding: 16px 18px;
+}
+
+.action-panel.visible,
+.dialogue-panel.visible,
+.battle-panel.visible,
+.auth-panel.visible {
   display: block;
 }
 
-.panel-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 12px;
+.dialogue-panel {
+  display: none;
+  position: absolute;
+  left: 18px;
+  bottom: 178px;
+  width: min(540px, calc(100% - 412px));
+  padding: 18px;
 }
 
+.battle-panel {
+  display: none;
+  position: absolute;
+  left: 18px;
+  bottom: 178px;
+  width: min(540px, calc(100% - 412px));
+  max-height: 58vh;
+  overflow: auto;
+  padding: 18px;
+}
+
+.auth-panel {
+  display: none;
+  position: absolute;
+  inset: 0;
+  background: rgba(7, 12, 10, 0.36);
+}
+
+.auth-card {
+  width: min(430px, calc(100% - 36px));
+  margin: 10vh auto 0;
+  padding: 24px;
+  border-radius: 28px;
+  background: var(--surface-strong);
+  border: 1px solid var(--line-strong);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.46);
+}
+
+.panel-header,
+.hud-row,
+.dock-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.hud-brand h1,
+.auth-card h2,
+.dock-header h2,
 .panel-header h2,
 .panel-header h3 {
   margin: 0;
-  font-size: 1rem;
 }
 
+.hud-brand h1 {
+  font-size: clamp(1.25rem, 2.2vw, 1.8rem);
+}
+
+.hud-brand p,
 .panel-note {
-  margin: 0;
-  color: #d1cabd;
+  margin: 6px 0 0;
+  color: var(--text-muted);
   line-height: 1.5;
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: "Space Mono", monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  color: var(--accent-gold);
+  text-transform: uppercase;
+}
+
+.eyebrow::before {
+  content: "";
+  width: 24px;
+  height: 1px;
+  background: currentColor;
+}
+
+.hud-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.status-pill,
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-main);
+  font-size: 0.86rem;
+}
+
+.status-pill.offline {
+  background: rgba(216, 109, 96, 0.18);
+}
+
+.status-pill.connecting {
+  background: rgba(242, 204, 143, 0.18);
+}
+
+.status-pill.online {
+  background: rgba(83, 181, 156, 0.18);
+}
+
+.pill.muted {
+  color: var(--text-muted);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.meter-grid {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.meter-card,
+.battle-stats div {
+  padding: 12px 14px;
+  border-radius: 18px;
+  background: var(--surface-soft);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.meter-card span,
+.battle-stats span {
+  display: block;
+  font-size: 0.75rem;
+  color: #c6b79f;
+}
+
+.meter-card strong,
+.battle-stats strong {
+  display: block;
+  margin-top: 4px;
+  font-size: 1.05rem;
 }
 
 .segmented {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 8px;
-  margin-bottom: 12px;
+  margin: 18px 0 14px;
 }
 
 .segmented button,
-.panel button,
-.panel input {
-  border-radius: 14px;
-}
-
-.panel button {
+.primary,
+.ghost,
+.battle-actions button,
+.action-stack button,
+.chat-form button,
+.dock-card {
   border: 0;
-  padding: 11px 14px;
-  background: #e76f51;
-  color: #fff8ef;
-  cursor: pointer;
-  transition: transform 180ms ease, opacity 180ms ease;
+  border-radius: 16px;
+  transition: transform 180ms ease, background 180ms ease, opacity 180ms ease;
 }
 
-.panel button:hover {
-  transform: translateY(-1px);
-}
-
-.panel button.ghost,
-.segmented button {
+.segmented button,
+.ghost,
+.action-stack button,
+.dock-card,
+.chat-form button {
   background: rgba(255, 255, 255, 0.08);
-  color: #f6f0e3;
+  color: var(--text-main);
 }
 
-.segmented button.active {
-  background: #2a9d8f;
+.segmented button.active,
+.primary {
+  background: linear-gradient(135deg, var(--accent-rust), var(--accent-gold));
+  color: #1f1b16;
+}
+
+.primary:hover,
+.ghost:hover,
+.segmented button:hover,
+.action-stack button:hover,
+.dock-card:hover,
+.chat-form button:hover,
+.battle-actions button:hover {
+  transform: translateY(-1px);
 }
 
 .auth-form {
   display: grid;
-  gap: 10px;
+  gap: 12px;
+  margin-top: 16px;
 }
 
 .auth-form label {
   display: grid;
   gap: 6px;
+  color: var(--text-muted);
   font-size: 0.92rem;
-  color: #ddd4c3;
 }
 
 .auth-form input,
 .chat-form input {
   border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
   background: rgba(0, 0, 0, 0.24);
-  color: #f7f3e9;
-  padding: 12px 14px;
+  color: var(--text-main);
+  padding: 13px 14px;
 }
 
-.stat-grid {
+.dock-summary,
+.presence-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.dock-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.dock-card {
+  display: grid;
+  gap: 6px;
+  padding: 14px;
+  text-align: left;
+}
+
+.dock-card strong {
+  font-size: 1rem;
+}
+
+.dock-card span {
+  color: var(--text-muted);
+  line-height: 1.45;
+}
+
+.dock-card.accent {
+  background: rgba(83, 181, 156, 0.18);
+}
+
+.dock-card.static {
+  cursor: default;
+}
+
+.dock-card.danger {
+  background: rgba(216, 109, 96, 0.15);
+}
+
+.dialogue-line {
+  margin: 14px 0 18px;
+  font-size: 1.06rem;
+  line-height: 1.75;
+}
+
+.battle-stats {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 10px;
+  margin: 14px 0;
 }
 
-.stat-grid div {
-  padding: 12px;
-  border-radius: 16px;
-  background: rgba(255, 255, 255, 0.05);
+.battle-actions {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  margin-bottom: 14px;
 }
 
-.stat-grid span {
-  display: block;
-  font-size: 0.76rem;
-  color: #baa88f;
-}
-
-.stat-grid strong {
-  display: block;
-  margin-top: 3px;
-  font-size: 1rem;
+.battle-actions button {
+  padding: 12px 14px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-main);
 }
 
 .action-stack {
   display: grid;
   gap: 8px;
-  margin-top: 12px;
+  margin-top: 14px;
 }
 
 .action-stack h3 {
-  margin: 0 0 4px;
+  margin: 0 0 2px;
   font-size: 0.95rem;
 }
 
@@ -209,72 +458,21 @@ input {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background: rgba(255, 255, 255, 0.08);
-}
-
-.action-wide {
-  width: 100%;
-}
-
-.pill {
-  display: inline-flex;
-  align-items: center;
-  padding: 6px 10px;
-  border-radius: 999px;
-  background: rgba(42, 157, 143, 0.16);
-  color: #d8fff8;
-  margin-right: 8px;
-}
-
-.dialogue-panel,
-.battle-panel {
-  display: none;
-}
-
-.dialogue-line {
-  margin: 0 0 12px;
-  font-size: 1.08rem;
-  line-height: 1.7;
-}
-
-.battle-stats {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 10px;
-  margin-bottom: 12px;
-}
-
-.battle-stats div {
-  padding: 10px 12px;
-  border-radius: 16px;
-  background: rgba(255, 255, 255, 0.05);
-}
-
-.battle-stats span {
-  display: block;
-  color: #baa88f;
-  font-size: 0.76rem;
-}
-
-.battle-actions {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 8px;
+  padding: 11px 14px;
 }
 
 .chat-list,
 .log-list {
   display: grid;
   gap: 8px;
-  max-height: 220px;
-  overflow: auto;
+  margin: 14px 0;
 }
 
 .chat-item,
 .log-item {
   padding: 10px 12px;
   border-radius: 16px;
-  background: rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.06);
 }
 
 .chat-item strong {
@@ -282,36 +480,107 @@ input {
   margin-bottom: 4px;
 }
 
+.chat-item span,
+.log-item {
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
 .chat-form {
   display: grid;
   grid-template-columns: 1fr auto;
   gap: 8px;
-  margin-top: 12px;
 }
 
-.status-dot {
-  font-size: 0.8rem;
-  text-transform: uppercase;
+@media (max-width: 1180px) {
+  .hud-panel {
+    right: 16px;
+  }
+
+  .log-panel {
+    width: 280px;
+  }
+
+  .chat-panel {
+    width: 300px;
+  }
+
+  .action-panel,
+  .dialogue-panel,
+  .battle-panel {
+    right: 332px;
+    width: auto;
+  }
+
+  .meter-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
 }
 
-.status-dot.online {
-  color: #70c1b3;
-}
+@media (max-width: 920px) {
+  .game-stage {
+    padding: 12px;
+  }
 
-.status-dot.connecting {
-  color: #ffe066;
-}
+  .stage-canvas,
+  .ui-layer {
+    inset: 12px;
+    border-radius: 24px;
+  }
 
-.status-dot.offline {
-  color: #f25f5c;
-}
+  .hud-panel,
+  .log-panel,
+  .chat-panel,
+  .action-panel,
+  .dialogue-panel,
+  .battle-panel {
+    position: static;
+    width: auto;
+    margin-top: 12px;
+  }
 
-@media (max-width: 1200px) {
-  .shell {
+  .ui-layer {
+    display: grid;
     grid-template-columns: 1fr;
+    align-content: start;
+    gap: 12px;
+    padding: 12px;
+    overflow: auto;
   }
 
   .stage-canvas {
-    min-height: 540px;
+    min-height: 58vh;
+  }
+
+  .auth-panel {
+    position: absolute;
+    inset: 0;
+  }
+
+  .battle-stats,
+  .meter-grid,
+  .dock-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .hud-row,
+  .dock-header,
+  .panel-header,
+  .chat-form {
+    grid-template-columns: 1fr;
+    display: grid;
+  }
+
+  .battle-actions,
+  .battle-stats,
+  .meter-grid,
+  .dock-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .auth-card {
+    margin-top: 6vh;
   }
 }

--- a/apps/web/src/ui/dom.ts
+++ b/apps/web/src/ui/dom.ts
@@ -35,24 +35,20 @@ export class DomUi {
   constructor(root: HTMLElement, private readonly callbacks: UiCallbacks) {
     this.root = root;
     this.root.innerHTML = `
-      <div class="shell">
-        <aside class="sidebar">
-          <section class="panel auth-panel"></section>
-          <section class="panel hud-panel"></section>
-          <section class="panel action-panel"></section>
-          <section class="panel log-panel"></section>
-        </aside>
-        <main class="stage-wrap">
-          <div class="stage-header">
-            <div>
-              <h1>RPG Rebuild</h1>
-              <p>탑다운 탐험, 지역 채팅, 유저 실시간 표시</p>
-            </div>
-          </div>
+      <div class="viewport-shell">
+        <div class="atmosphere atmosphere-one"></div>
+        <div class="atmosphere atmosphere-two"></div>
+        <main class="game-stage">
           <div class="stage-canvas"></div>
-          <section class="panel dialogue-panel"></section>
-          <section class="panel battle-panel"></section>
-          <section class="panel chat-panel"></section>
+          <div class="ui-layer">
+            <header class="panel hud-panel"></header>
+            <aside class="panel log-panel"></aside>
+            <aside class="panel chat-panel"></aside>
+            <section class="panel action-panel"></section>
+            <section class="panel dialogue-panel"></section>
+            <section class="panel battle-panel"></section>
+            <section class="panel auth-panel"></section>
+          </div>
         </main>
       </div>
     `;
@@ -81,7 +77,7 @@ export class DomUi {
     learnedTactics: TacticDefinition[],
   ): void {
     this.renderAuth(state);
-    this.renderHud(state.player, currentLocation);
+    this.renderHud(state, currentLocation);
     this.renderActions(state.player, currentLocation, state.battle, equipmentForLocation, skillForLocation, equipped);
     this.renderDialogue(state);
     this.renderBattle(state.battle, learnedSkills, learnedTactics);
@@ -90,27 +86,37 @@ export class DomUi {
   }
 
   private renderAuth(state: AppState): void {
+    if (state.player) {
+      this.authPanel.classList.remove("visible");
+      this.authPanel.innerHTML = "";
+      return;
+    }
+
     const disabled = state.pending ? "disabled" : "";
+    this.authPanel.classList.add("visible");
     this.authPanel.innerHTML = `
-      <div class="panel-header">
-        <h2>계정</h2>
+      <div class="auth-card">
+        <div class="eyebrow">LOGIN</div>
+        <h2>탐험가 등록소</h2>
+        <p class="panel-note">접속 후에는 오버월드에서 바로 이동과 상호작용을 이어갈 수 있습니다.</p>
+        <div class="segmented">
+          <button class="${state.authMode === "login" ? "active" : ""}" data-auth-mode="login">로그인</button>
+          <button class="${state.authMode === "register" ? "active" : ""}" data-auth-mode="register">회원가입</button>
+        </div>
+        <form class="auth-form">
+          <label>
+            아이디
+            <input name="username" autocomplete="username" ${disabled} />
+          </label>
+          <label>
+            비밀번호
+            <input type="password" name="password" autocomplete="current-password" ${disabled} />
+          </label>
+          <button type="submit" class="primary" ${disabled}>
+            ${state.pending ? "처리 중..." : state.authMode === "login" ? "접속하기" : "모험 시작"}
+          </button>
+        </form>
       </div>
-      <div class="segmented">
-        <button class="${state.authMode === "login" ? "active" : ""}" data-auth-mode="login">로그인</button>
-        <button class="${state.authMode === "register" ? "active" : ""}" data-auth-mode="register">회원가입</button>
-      </div>
-      <form class="auth-form">
-        <label>
-          아이디
-          <input name="username" autocomplete="username" ${disabled} />
-        </label>
-        <label>
-          비밀번호
-          <input type="password" name="password" autocomplete="current-password" ${disabled} />
-        </label>
-        <button type="submit" ${disabled}>${state.authMode === "login" ? "접속" : "시작하기"}</button>
-      </form>
-      <p class="panel-note">${state.player ? `${state.player.username} 접속 중` : "로그인 후 게임이 시작됩니다."}</p>
     `;
 
     this.authPanel.querySelectorAll<HTMLButtonElement>("[data-auth-mode]").forEach((button) => {
@@ -129,32 +135,31 @@ export class DomUi {
     };
   }
 
-  private renderHud(player: PlayerSave | null, currentLocation: LocationNode | null): void {
-    if (!player) {
-      this.hudPanel.innerHTML = `
-        <div class="panel-header"><h2>상태</h2></div>
-        <p class="panel-note">접속하면 현재 위치와 스탯이 여기에 표시됩니다.</p>
-      `;
-      return;
-    }
+  private renderHud(state: AppState, currentLocation: LocationNode | null): void {
+    const nearbyPlayers = state.presence.filter((entry) => entry.username !== state.player?.username);
+    const locationTitle = currentLocation ? `${currentLocation.mainLocation} · ${currentLocation.subLocation}` : "월드 로딩 중";
 
     this.hudPanel.innerHTML = `
-      <div class="panel-header">
-        <h2>상태</h2>
-        <button class="ghost" data-save>저장</button>
+      <div class="hud-row">
+        <div class="hud-brand">
+          <div class="eyebrow">OVERWORLD MVP</div>
+          <h1>${locationTitle}</h1>
+          <p>${state.player ? "WASD 이동 · Space 대화 · Enter 전환 · B 교전" : "접속 후 오버월드 탐험이 활성화됩니다."}</p>
+        </div>
+        <div class="hud-meta">
+          <span class="status-pill ${state.connectionStatus}">${state.connectionStatus}</span>
+          <button class="ghost" data-save ${state.player ? "" : "disabled"}>저장</button>
+        </div>
       </div>
-      <div class="stat-grid">
-        <div><span>위치</span><strong>${currentLocation?.mainLocation ?? "-"}</strong></div>
-        <div><span>세부</span><strong>${currentLocation?.subLocation ?? "-"}</strong></div>
-        <div><span>레벨</span><strong>${player.level}</strong></div>
-        <div><span>코인</span><strong>${player.coins}</strong></div>
-        <div><span>HP</span><strong>${Math.round(player.currentHp)}</strong></div>
-        <div><span>MP</span><strong>${Math.round(player.currentMp)}</strong></div>
-        <div><span>공격</span><strong>${player.attack}</strong></div>
-        <div><span>방어</span><strong>${player.defense}</strong></div>
+      <div class="meter-grid">
+        ${state.player ? this.renderPlayerMeters(state.player, nearbyPlayers.length) : this.renderLoadingMeters(state)}
       </div>
     `;
-    (this.hudPanel.querySelector("[data-save]") as HTMLButtonElement).onclick = () => this.callbacks.onSave();
+
+    const saveButton = this.hudPanel.querySelector<HTMLButtonElement>("[data-save]");
+    if (saveButton) {
+      saveButton.onclick = () => this.callbacks.onSave();
+    }
   }
 
   private renderActions(
@@ -166,7 +171,8 @@ export class DomUi {
     equipped: EquipmentDefinition[],
   ): void {
     if (!player || !currentLocation) {
-      this.actionPanel.innerHTML = `<div class="panel-header"><h2>행동</h2></div><p class="panel-note">게임에 접속하면 상점과 휴식 메뉴가 열립니다.</p>`;
+      this.actionPanel.classList.remove("visible");
+      this.actionPanel.innerHTML = "";
       return;
     }
 
@@ -176,9 +182,9 @@ export class DomUi {
         const owned = player.ownedEquipmentIds.includes(item.id);
         const equippedState = player.equippedEquipmentIds.includes(item.id);
         return `
-          <button data-equipment="${item.id}">
-            ${owned ? (equippedState ? "장착 해제/교체" : "장착") : `구매 ${item.cost}`}
-            <span>${item.name}</span>
+          <button class="dock-card" data-equipment="${item.id}">
+            <strong>${item.name}</strong>
+            <span>${owned ? (equippedState ? "장착 해제/교체" : "장착") : `${item.cost} 코인 구매`}</span>
           </button>
         `;
       })
@@ -187,24 +193,37 @@ export class DomUi {
       .map((skill) => {
         const learned = player.learnedSkillIds.includes(skill.id);
         return `
-          <button data-skill="${skill.id}">
-            ${learned ? "습득 완료" : `습득 ${skill.cost}`}
-            <span>${skill.name}</span>
+          <button class="dock-card" data-skill="${skill.id}">
+            <strong>${skill.name}</strong>
+            <span>${learned ? "습득 완료" : `${skill.cost} 코인 습득`}</span>
           </button>
         `;
       })
       .join("");
+    const equippedPills = equipped.length > 0
+      ? equipped.map((item) => `<span class="pill">${item.name}</span>`).join("")
+      : `<span class="pill muted">장착 없음</span>`;
 
+    const hasContextActions = restingVisible || equipmentButtons || skillButtons;
+    this.actionPanel.classList.add("visible");
     this.actionPanel.innerHTML = `
-      <div class="panel-header">
-        <h2>현장 메뉴</h2>
+      <div class="dock-header">
+        <div>
+          <div class="eyebrow">FIELD ACTIONS</div>
+          <h2>${currentLocation.subLocation}</h2>
+        </div>
+        <div class="dock-summary">
+          <span class="pill">${currentLocation.mainLocation}</span>
+          ${equippedPills}
+        </div>
       </div>
-      <div class="panel-note">전투 중에는 전투 패널을 사용하세요. 탐험 중에는 위치에 맞는 상호작용이 열립니다.</div>
-      ${restingVisible ? `<button class="action-wide" data-rest>숙박 20 코인</button>` : ""}
-      ${equipmentButtons ? `<div class="action-stack"><h3>무기 상점</h3>${equipmentButtons}</div>` : ""}
-      ${skillButtons ? `<div class="action-stack"><h3>기술 상점</h3>${skillButtons}</div>` : ""}
-      ${equipped.length > 0 ? `<div class="action-stack"><h3>장착 중</h3>${equipped.map((item) => `<span class="pill">${item.name}</span>`).join("")}</div>` : ""}
-      ${battle ? `<p class="panel-note">전투가 진행 중이라 상점/휴식은 비활성 상태입니다.</p>` : ""}
+      <div class="dock-grid">
+        ${restingVisible ? `<button class="dock-card accent" data-rest><strong>숙박</strong><span>20 코인으로 HP/MP 회복</span></button>` : ""}
+        ${equipmentButtons}
+        ${skillButtons}
+        ${!hasContextActions ? `<div class="dock-card static"><strong>탐험 구간</strong><span>출구 진입 후 Enter 로 씬 전환, NPC 근처에서 Space 로 대화</span></div>` : ""}
+        ${battle ? `<div class="dock-card static danger"><strong>전투 진행 중</strong><span>오른쪽 전투 오버레이에서 행동을 선택하세요.</span></div>` : ""}
+      </div>
     `;
 
     this.actionPanel.querySelectorAll<HTMLButtonElement>("[data-equipment]").forEach((button) => {
@@ -232,9 +251,13 @@ export class DomUi {
     const currentLine = state.dialogue.lines[state.dialogue.index] ?? "";
     this.dialoguePanel.classList.add("visible");
     this.dialoguePanel.innerHTML = `
-      <div class="panel-header"><h2>${state.dialogue.title}</h2></div>
+      <div class="eyebrow">DIALOGUE</div>
+      <div class="panel-header">
+        <h2>${state.dialogue.title}</h2>
+        <span>${state.dialogue.index + 1} / ${state.dialogue.lines.length}</span>
+      </div>
       <p class="dialogue-line">${currentLine}</p>
-      <button data-dialogue-next>${state.dialogue.index >= state.dialogue.lines.length - 1 ? "닫기" : "다음"}</button>
+      <button class="primary" data-dialogue-next>${state.dialogue.index >= state.dialogue.lines.length - 1 ? "닫기" : "다음"}</button>
     `;
     (this.dialoguePanel.querySelector("[data-dialogue-next]") as HTMLButtonElement).onclick = () => this.callbacks.onDialogueNext();
   }
@@ -248,12 +271,16 @@ export class DomUi {
 
     this.battlePanel.classList.add("visible");
     this.battlePanel.innerHTML = `
-      <div class="panel-header"><h2>전투</h2></div>
+      <div class="eyebrow">BATTLE</div>
+      <div class="panel-header">
+        <h2>${battle.enemy.name}</h2>
+        <span>턴 ${battle.turnNumber}</span>
+      </div>
       <div class="battle-stats">
-        <div><span>적</span><strong>${battle.enemy.name}</strong></div>
         <div><span>적 HP</span><strong>${Math.round(battle.enemy.currentHp)} / ${battle.enemy.maxHp}</strong></div>
         <div><span>내 HP</span><strong>${Math.round(battle.player.currentHp)} / ${battle.player.maxHp}</strong></div>
         <div><span>내 MP</span><strong>${Math.round(battle.player.currentMp)} / ${battle.player.maxMp}</strong></div>
+        <div><span>전황</span><strong>${battle.isBoss ? "보스전" : "일반전"}</strong></div>
       </div>
       <div class="battle-actions">
         <button data-battle-basic="attack">공격</button>
@@ -282,20 +309,28 @@ export class DomUi {
   }
 
   private renderChat(state: AppState): void {
+    const nearbyPlayers = state.presence.filter((entry) => entry.username !== state.player?.username);
+
     this.chatPanel.innerHTML = `
       <div class="panel-header">
-        <h2>지역 채팅</h2>
-        <span class="status-dot ${state.connectionStatus}">${state.connectionStatus}</span>
+        <div>
+          <div class="eyebrow">SOCIAL</div>
+          <h2>지역 채팅</h2>
+        </div>
+        <span class="status-pill ${state.connectionStatus}">${nearbyPlayers.length} nearby</span>
+      </div>
+      <div class="presence-strip">
+        ${nearbyPlayers.map((presence) => `<span class="pill">${presence.username}</span>`).join("") || `<span class="pill muted">같은 씬의 다른 유저 없음</span>`}
       </div>
       <div class="chat-list">
         ${state.chatMessages
-          .slice(-12)
+          .slice(-8)
           .map((message) => `<div class="chat-item"><strong>${message.username}</strong><span>${message.text}</span></div>`)
-          .join("") || `<p class="panel-note">같은 씬의 다른 유저와 대화할 수 있습니다.</p>`}
+          .join("") || `<p class="panel-note">같은 씬의 유저에게 말을 걸 수 있습니다.</p>`}
       </div>
       <form class="chat-form">
         <input name="text" placeholder="같은 씬의 유저에게 말하기" ${state.player ? "" : "disabled"} />
-        <button type="submit" ${state.player ? "" : "disabled"}>전송</button>
+        <button type="submit" class="primary" ${state.player ? "" : "disabled"}>전송</button>
       </form>
     `;
     const form = this.chatPanel.querySelector(".chat-form") as HTMLFormElement;
@@ -312,10 +347,34 @@ export class DomUi {
 
   private renderLogs(logs: string[]): void {
     this.logPanel.innerHTML = `
-      <div class="panel-header"><h2>이벤트 로그</h2></div>
-      <div class="log-list">
-        ${logs.map((entry) => `<div class="log-item">${entry}</div>`).join("") || `<p class="panel-note">전투, 상점, 저장 결과가 여기에 기록됩니다.</p>`}
+      <div class="panel-header">
+        <div>
+          <div class="eyebrow">EVENT FEED</div>
+          <h2>최근 이벤트</h2>
+        </div>
       </div>
+      <div class="log-list">
+        ${logs.slice(0, 6).map((entry) => `<div class="log-item">${entry}</div>`).join("") || `<p class="panel-note">저장, 이동, 전투 결과가 여기에 쌓입니다.</p>`}
+      </div>
+    `;
+  }
+
+  private renderPlayerMeters(player: PlayerSave, nearbyCount: number): string {
+    return `
+      <div class="meter-card"><span>Lv</span><strong>${player.level}</strong></div>
+      <div class="meter-card"><span>HP</span><strong>${Math.round(player.currentHp)}</strong></div>
+      <div class="meter-card"><span>MP</span><strong>${Math.round(player.currentMp)}</strong></div>
+      <div class="meter-card"><span>Coin</span><strong>${player.coins}</strong></div>
+      <div class="meter-card"><span>Atk</span><strong>${player.attack}</strong></div>
+      <div class="meter-card"><span>Nearby</span><strong>${nearbyCount}</strong></div>
+    `;
+  }
+
+  private renderLoadingMeters(state: AppState): string {
+    return `
+      <div class="meter-card"><span>World</span><strong>${state.world ? "ready" : "loading"}</strong></div>
+      <div class="meter-card"><span>Status</span><strong>${state.pending ? "auth" : "idle"}</strong></div>
+      <div class="meter-card"><span>Scene</span><strong>${state.world ? "login" : "boot"}</strong></div>
     `;
   }
 }


### PR DESCRIPTION
## 연결 이슈
- Closes #4

## 작업 내용
- Phaser 씬 구성을 boot/loading/login/overworld 흐름으로 정리
- 플레이어 추적 카메라와 포털, NPC, 조우 존의 오버월드 애니메이션을 추가
- DOM UI를 사이드바 중심에서 게임 화면 중심 HUD/오버레이 구조로 개편
- 로그인 오버레이, 상호작용 독 패널, 전투 오버레이, 채팅/이벤트 피드를 오버월드 위에 배치
- 브라우저에서 텍스트 중심 레이아웃 없이 탐험 루프를 유지할 수 있도록 레이아웃과 스타일을 전면 조정

## 검증
- 로컬에서 툴체인 실행 경로가 merge 이후 꼬여서 전체 web typecheck/test/lint/build 를 안정적으로 끝까지 재현하지 못했습니다.
- 대신 다음은 확인했습니다.
- vite --version 정상 응답
- tsc --showConfig 정상 응답
- 변경 파일 기준 타입 확인 시 실제 코드 오류 대신 전역 타입 해석과 셸 경로 이슈가 먼저 드러나는 상태
- 최종 검증은 PR CI quality 체크로 확인 예정

## 메모
- 이번 PR은 오버월드 탐험 체감과 HUD 구조 정리에 집중했습니다.
- 전투 HUD 세부 연출과 상점/대화 UX 미세 조정은 다음 단계에서 더 다듬을 수 있습니다.