### PR TITLE
feat: 대화 전투 HUD 흐름을 2D 클라이언트에 통합

### DIFF
--- a/apps/web/src/AppController.ts
+++ b/apps/web/src/AppController.ts
@@ -19,6 +19,7 @@ import {
   performBattleAction,
   pickRandom,
 } from "@rpg/game-core";
+import { createBattleReport, deriveOverlayMode, didSceneChange } from "./gameplay";
 import { ApiClient } from "./net/api";
 import { PresenceClient } from "./net/socket";
 import { GameBridge } from "./game/GameBridge";
@@ -34,6 +35,33 @@ export class AppController {
   private readonly game: GameBridge;
   private readonly presence: PresenceClient;
   private lastSavedAt = 0;
+  private readonly handleGlobalKeydown = (event: KeyboardEvent) => {
+    if (this.isTextEntryTarget(event.target)) {
+      return;
+    }
+
+    const state = this.store.getState();
+    if (state.dialogue && (event.key === "Enter" || event.key === " ")) {
+      event.preventDefault();
+      void this.advanceDialogue();
+      return;
+    }
+
+    if (!state.battle) {
+      return;
+    }
+
+    if (event.key === "1") {
+      event.preventDefault();
+      void this.performAction({ kind: "attack" });
+    } else if (event.key === "2") {
+      event.preventDefault();
+      void this.performAction({ kind: "normal" });
+    } else if (event.key === "3") {
+      event.preventDefault();
+      void this.performAction({ kind: "defend" });
+    }
+  };
 
   constructor(root: HTMLElement) {
     this.ui = new DomUi(root, {
@@ -70,6 +98,7 @@ export class AppController {
         const state = this.store.getState();
         return Boolean(state.player && !state.battle && !state.dialogue);
       },
+      getOverlayMode: () => deriveOverlayMode(this.store.getState()),
       onPositionChange: (x, y, facing) => this.updatePosition(x, y, facing),
       onSceneChange: (locationKey) => {
         void this.changeLocation(locationKey);
@@ -78,6 +107,7 @@ export class AppController {
       onEncounter: (zone) => {
         void this.startEncounter(zone);
       },
+      onFieldPromptChange: (prompt) => this.store.setState({ fieldPrompt: prompt }),
     });
 
     this.presence = new PresenceClient(import.meta.env.VITE_API_BASE_URL ?? "http://localhost:4000", {
@@ -96,9 +126,9 @@ export class AppController {
 
     this.store.subscribe((state) => {
       const currentLocation = state.player && state.world ? state.world.locations[state.player.locationKey] ?? null : null;
-      const equipmentMap = this.equipmentMap;
-      const skillMap = this.skillMap;
-      const tacticMap = this.tacticMap;
+      const equipmentMap: Record<string, EquipmentDefinition> = state.world ? this.equipmentMap : {};
+      const skillMap: Record<string, SkillDefinition> = state.world ? this.skillMap : {};
+      const tacticMap: Record<string, TacticDefinition> = state.world ? this.tacticMap : {};
       const equipmentForLocation = currentLocation
         ? currentLocation.subLocation === "무기 상점"
           ? Object.values(equipmentMap).filter((item) => item.village === currentLocation.mainLocation)
@@ -122,6 +152,8 @@ export class AppController {
       this.ui.render(state, currentLocation, equipmentForLocation, skillsForLocation, equipped, learnedSkills, learnedTactics);
       this.game.sync(state.world, state.player, state.presence);
     });
+
+    window.addEventListener("keydown", this.handleGlobalKeydown);
   }
 
   async start(): Promise<void> {
@@ -134,7 +166,7 @@ export class AppController {
       if (token) {
         try {
           const player = await this.api.me(token);
-          this.store.setState({ token, player, pending: false });
+          this.store.setState({ token, player, pending: false, battleReport: null });
           this.presence.connect(token);
           this.enterPresence(player, false);
           await this.maybeOpenLocationDialogue(player.locationKey);
@@ -184,6 +216,7 @@ export class AppController {
         token: session.token,
         player: session.player,
         battle: null,
+        battleReport: null,
         dialogue: null,
         chatMessages: [],
         presence: [],
@@ -238,6 +271,7 @@ export class AppController {
 
     this.store.setState({
       player: nextPlayer,
+      battleReport: null,
       presence: [],
       chatMessages: [],
     });
@@ -260,7 +294,9 @@ export class AppController {
         lines: npc.lines,
         index: 0,
       },
+      battleReport: null,
     });
+    this.store.pushLog(`${npc.name}와(과) 대화를 시작합니다.`);
   }
 
   private async maybeOpenLocationDialogue(locationKey: string): Promise<void> {
@@ -287,6 +323,7 @@ export class AppController {
           lines: location.story,
           index: story.currentIndex,
         },
+        battleReport: null,
       });
     }
   }
@@ -322,6 +359,7 @@ export class AppController {
       player: nextPlayer,
       dialogue: null,
     });
+    this.store.pushLog(`${state.dialogue.title} 대화 종료`);
     await this.savePlayer();
   }
 
@@ -339,6 +377,7 @@ export class AppController {
 
     this.store.setState({
       battle: createBattle(state.player, enemy),
+      battleReport: null,
     });
     this.store.pushLog(`${enemy.name}과(와) 전투를 시작합니다.`);
   }
@@ -359,6 +398,7 @@ export class AppController {
       enemies: this.world.enemies,
     });
 
+    const previousPlayer = state.player;
     let nextPlayer = resolution.player;
     if (resolution.state.finished && resolution.state.outcome === "player_win") {
       const bossName = this.currentLocation?.bossName;
@@ -373,11 +413,24 @@ export class AppController {
       }
     }
 
+    const sceneChangedAfterBattle = didSceneChange(this.world, previousPlayer, nextPlayer);
+    const battleReport = createBattleReport({
+      ...resolution,
+      player: nextPlayer,
+    });
+
     this.store.setState({
       player: nextPlayer,
       battle: resolution.state.finished ? null : resolution.state,
+      battleReport,
+      chatMessages: sceneChangedAfterBattle ? [] : state.chatMessages,
+      presence: sceneChangedAfterBattle ? [] : state.presence,
     });
     resolution.logs.slice(-4).forEach((entry) => this.store.pushLog(entry));
+    if (sceneChangedAfterBattle) {
+      this.enterPresence(nextPlayer, true);
+      await this.maybeOpenLocationDialogue(nextPlayer.locationKey);
+    }
     await this.savePlayer();
   }
 
@@ -528,6 +581,13 @@ export class AppController {
       ...state,
       presence: state.presence.filter((entry) => entry.username !== username),
     }));
+  }
+
+  private isTextEntryTarget(target: EventTarget | null): boolean {
+    if (!(target instanceof HTMLElement)) {
+      return false;
+    }
+    return target.closest("input, textarea, [contenteditable='true']") !== null;
   }
 
   private applyEquipmentSelection(player: PlayerSave, equippedEquipmentIds: string[]): PlayerSave {

--- a/apps/web/src/game/GameBridge.ts
+++ b/apps/web/src/game/GameBridge.ts
@@ -1,5 +1,6 @@
 import Phaser from "phaser";
 import type { DialogueNpc, EncounterZone, Facing, PlayerSave, PresenceState, WorldContent } from "@rpg/game-core";
+import type { FieldPrompt, OverlayMode } from "../gameplay";
 import { BootScene } from "./BootScene";
 import { LoadingScene } from "./LoadingScene";
 import { LoginScene } from "./LoginScene";
@@ -7,10 +8,12 @@ import { OverworldScene } from "./OverworldScene";
 
 type BridgeCallbacks = {
   canMove: () => boolean;
+  getOverlayMode: () => OverlayMode;
   onPositionChange: (x: number, y: number, facing: Facing) => void;
   onSceneChange: (locationKey: string) => void;
   onInteractNpc: (npc: DialogueNpc) => void;
   onEncounter: (zone: EncounterZone) => void;
+  onFieldPromptChange: (prompt: FieldPrompt) => void;
 };
 
 export class GameBridge {

--- a/apps/web/src/game/OverworldScene.ts
+++ b/apps/web/src/game/OverworldScene.ts
@@ -8,13 +8,16 @@ import type {
   SceneDefinition,
   WorldContent,
 } from "@rpg/game-core";
+import type { FieldPrompt, OverlayMode } from "../gameplay";
 
 type SceneCallbacks = {
   canMove: () => boolean;
+  getOverlayMode: () => OverlayMode;
   onPositionChange: (x: number, y: number, facing: Facing) => void;
   onSceneChange: (locationKey: string) => void;
   onInteractNpc: (npc: DialogueNpc) => void;
   onEncounter: (zone: EncounterZone) => void;
+  onFieldPromptChange: (prompt: FieldPrompt) => void;
 };
 
 type TiledProperty = {
@@ -63,7 +66,11 @@ export class OverworldScene extends Phaser.Scene {
   private keySpace!: Phaser.Input.Keyboard.Key;
   private keyBattle!: Phaser.Input.Keyboard.Key;
   private hintText!: Phaser.GameObjects.Text;
+  private overlayShade!: Phaser.GameObjects.Rectangle;
+  private overlayText!: Phaser.GameObjects.Text;
   private lastPresenceSentAt = 0;
+  private lastBroadcastKey = "";
+  private lastPromptKey = "";
 
   constructor() {
     super("overworld");
@@ -145,30 +152,33 @@ export class OverworldScene extends Phaser.Scene {
   }
 
   update(time: number, delta: number): void {
-    if (!this.playerState || !this.callbacks || !this.sceneDefinition || !this.playerSprite || !this.hintText) {
+    if (!this.playerState || !this.callbacks || !this.sceneDefinition || !this.playerSprite || !this.hintText || !this.overlayShade || !this.overlayText) {
       return;
     }
 
-    const canMove = this.callbacks.canMove();
-    const speed = canMove ? 160 : 0;
+    const overlayMode = this.callbacks.getOverlayMode();
+    const canExplore = overlayMode === "explore" && this.callbacks.canMove();
+    const speed = canExplore ? 160 : 0;
     let velocityX = 0;
     let velocityY = 0;
     let facing: Facing = this.playerState.facing;
 
-    if (this.cursorKeys.left.isDown || this.keyA.isDown) {
-      velocityX = -1;
-      facing = "left";
-    } else if (this.cursorKeys.right.isDown || this.keyD.isDown) {
-      velocityX = 1;
-      facing = "right";
-    }
+    if (canExplore) {
+      if (this.cursorKeys.left.isDown || this.keyA.isDown) {
+        velocityX = -1;
+        facing = "left";
+      } else if (this.cursorKeys.right.isDown || this.keyD.isDown) {
+        velocityX = 1;
+        facing = "right";
+      }
 
-    if (this.cursorKeys.up.isDown || this.keyW.isDown) {
-      velocityY = -1;
-      facing = "up";
-    } else if (this.cursorKeys.down.isDown || this.keyS.isDown) {
-      velocityY = 1;
-      facing = "down";
+      if (this.cursorKeys.up.isDown || this.keyW.isDown) {
+        velocityY = -1;
+        facing = "up";
+      } else if (this.cursorKeys.down.isDown || this.keyS.isDown) {
+        velocityY = 1;
+        facing = "down";
+      }
     }
 
     const distance = speed * (delta / 1000);
@@ -184,38 +194,43 @@ export class OverworldScene extends Phaser.Scene {
       facing,
     };
 
-    if (time - this.lastPresenceSentAt > 120) {
+    const broadcastKey = `${Math.round(nextX)}:${Math.round(nextY)}:${facing}`;
+    if (canExplore && time - this.lastPresenceSentAt > 120 && broadcastKey !== this.lastBroadcastKey) {
       this.callbacks.onPositionChange(nextX, nextY, facing);
       this.lastPresenceSentAt = time;
+      this.lastBroadcastKey = broadcastKey;
     }
 
-    let hint = `${this.sceneDefinition.sceneId}  |  이동: WASD / 화살표  |  상호작용: Space  |  전투: B  |  출구: Enter`;
-
-    this.portals.forEach((portal) => {
-      if (Phaser.Geom.Rectangle.Contains(portal.zone, nextX, nextY) && Phaser.Input.Keyboard.JustDown(this.keyEnter)) {
-        this.callbacks?.onSceneChange(portal.locationKey);
-      }
+    const activePortal = this.findActivePortal(nextX, nextY);
+    const activeNpc = this.findActiveNpc(nextX, nextY);
+    const activeEncounter = this.findActiveEncounter(nextX, nextY);
+    const prompt = this.resolvePrompt({
+      overlayMode,
+      portal: activePortal,
+      npc: activeNpc?.npc ?? null,
+      encounter: activeEncounter?.data ?? null,
     });
+    this.syncFieldPrompt(prompt);
+    this.syncOverlayState(overlayMode);
+    this.hintText.setText(`${prompt.title}  |  ${prompt.actionLabel}`);
 
-    this.npcMarkers.forEach(({ sprite, npc }) => {
-      if (Phaser.Math.Distance.Between(sprite.x, sprite.y, nextX, nextY) < 64) {
-        hint = `${npc.name}와 대화하려면 Space`;
-        if (Phaser.Input.Keyboard.JustDown(this.keySpace)) {
-          this.callbacks?.onInteractNpc(npc);
-        }
-      }
-    });
+    if (!canExplore) {
+      return;
+    }
 
-    this.encounterZones.forEach(({ zone, data }) => {
-      if (Phaser.Geom.Rectangle.Contains(zone, nextX, nextY)) {
-        hint = "전투 지역입니다. B 를 눌러 적과 교전할 수 있습니다.";
-        if (Phaser.Input.Keyboard.JustDown(this.keyBattle)) {
-          this.callbacks?.onEncounter(data);
-        }
-      }
-    });
+    if (activePortal && Phaser.Input.Keyboard.JustDown(this.keyEnter)) {
+      this.callbacks.onSceneChange(activePortal.locationKey);
+      return;
+    }
 
-    this.hintText.setText(hint);
+    if (activeNpc && Phaser.Input.Keyboard.JustDown(this.keySpace)) {
+      this.callbacks.onInteractNpc(activeNpc.npc);
+      return;
+    }
+
+    if (activeEncounter && Phaser.Input.Keyboard.JustDown(this.keyBattle)) {
+      this.callbacks.onEncounter(activeEncounter.data);
+    }
   }
 
   private buildLocation(): void {
@@ -236,6 +251,8 @@ export class OverworldScene extends Phaser.Scene {
     this.encounterZones = [];
     this.collisionZones = [];
     this.npcMarkers = [];
+    this.lastPromptKey = "";
+    this.lastBroadcastKey = "";
     this.remoteSprites.forEach((sprite) => sprite.destroy());
     this.remoteSprites.clear();
 
@@ -341,11 +358,126 @@ export class OverworldScene extends Phaser.Scene {
       })
       .setScrollFactor(0)
       .setDepth(20);
+    this.overlayShade = this.add
+      .rectangle(location.scene.width / 2, location.scene.height / 2, location.scene.width, location.scene.height, 0x070b09, 0)
+      .setDepth(18);
+    this.overlayText = this.add
+      .text(20, 56, "", {
+        color: "#f4efe3",
+        fontFamily: "Space Mono, monospace",
+        fontSize: "12px",
+        letterSpacing: 2,
+      })
+      .setScrollFactor(0)
+      .setDepth(21);
 
     this.cameras.main.setBounds(0, 0, location.scene.width, location.scene.height);
     this.cameras.main.startFollow(this.playerSprite, true, 0.12, 0.12);
     this.cameras.main.setDeadzone(220, 160);
     this.cameras.main.roundPixels = true;
+  }
+
+  private findActivePortal(x: number, y: number): { zone: Phaser.Geom.Rectangle; locationKey: string; label: string } | null {
+    return this.portals.find((portal) => Phaser.Geom.Rectangle.Contains(portal.zone, x, y)) ?? null;
+  }
+
+  private findActiveNpc(x: number, y: number): { sprite: Phaser.GameObjects.Sprite; npc: DialogueNpc } | null {
+    return this.npcMarkers.find(({ sprite }) => Phaser.Math.Distance.Between(sprite.x, sprite.y, x, y) < 64) ?? null;
+  }
+
+  private findActiveEncounter(x: number, y: number): { zone: Phaser.Geom.Rectangle; data: EncounterZone } | null {
+    return this.encounterZones.find(({ zone }) => Phaser.Geom.Rectangle.Contains(zone, x, y)) ?? null;
+  }
+
+  private resolvePrompt(params: {
+    overlayMode: OverlayMode;
+    portal: { label: string } | null;
+    npc: DialogueNpc | null;
+    encounter: EncounterZone | null;
+  }): FieldPrompt {
+    if (params.overlayMode === "battle") {
+      return {
+        kind: "battle",
+        title: "전투 진행 중",
+        body: "오른쪽 전투 패널에서 행동을 선택하거나 1, 2, 3 키로 기본 행동을 실행하세요.",
+        actionLabel: "전투 패널 / 숫자키 1-3",
+        tone: "danger",
+      };
+    }
+
+    if (params.overlayMode === "dialogue") {
+      return {
+        kind: "dialogue",
+        title: "대화 진행 중",
+        body: "Space 또는 Enter 로 다음 대사를 넘기고, 마지막 줄에서 대화를 닫을 수 있습니다.",
+        actionLabel: "Space / Enter",
+        tone: "accent",
+      };
+    }
+
+    if (params.portal) {
+      return {
+        kind: "portal",
+        title: `${params.portal.label} 이동 준비`,
+        body: "출구 위에서 Enter 를 누르면 다음 씬으로 전환됩니다.",
+        actionLabel: "Enter",
+        tone: "accent",
+      };
+    }
+
+    if (params.encounter) {
+      return {
+        kind: "encounter",
+        title: "적 조우 가능 구역",
+        body: "B 키를 눌러 현재 지역 적과 교전할 수 있습니다.",
+        actionLabel: "B",
+        tone: "danger",
+      };
+    }
+
+    if (params.npc) {
+      return {
+        kind: "npc",
+        title: `${params.npc.name}와 대화`,
+        body: "NPC 근처에서 Space 를 누르면 대화 패널이 열립니다.",
+        actionLabel: "Space",
+        tone: "accent",
+      };
+    }
+
+    return {
+      kind: "idle",
+      title: this.sceneDefinition?.sceneId ?? "오버월드 탐험",
+      body: "WASD 이동, Enter 씬 전환, Space 대화, B 전투로 현재 지역을 탐험하세요.",
+      actionLabel: "WASD / Space / Enter / B",
+      tone: "neutral",
+    };
+  }
+
+  private syncFieldPrompt(prompt: FieldPrompt): void {
+    const promptKey = `${prompt.kind}:${prompt.title}:${prompt.body}:${prompt.actionLabel}:${prompt.tone}`;
+    if (promptKey === this.lastPromptKey) {
+      return;
+    }
+    this.lastPromptKey = promptKey;
+    this.callbacks?.onFieldPromptChange(prompt);
+  }
+
+  private syncOverlayState(mode: OverlayMode): void {
+    if (mode === "battle") {
+      this.overlayShade.setAlpha(0.22).setFillStyle(0x2d1010, 0.22);
+      this.overlayText.setText("BATTLE LOCK").setAlpha(1);
+      return;
+    }
+
+    if (mode === "dialogue") {
+      this.overlayShade.setAlpha(0.16).setFillStyle(0x10261d, 0.16);
+      this.overlayText.setText("DIALOGUE LOCK").setAlpha(1);
+      return;
+    }
+
+    this.overlayShade.setAlpha(0);
+    this.overlayText.setText("").setAlpha(0);
   }
 
   private renderSceneMap(scene: SceneDefinition): void {

--- a/apps/web/src/gameplay.ts
+++ b/apps/web/src/gameplay.ts
@@ -1,0 +1,68 @@
+import type { BattleResolution, PlayerSave, WorldContent } from "@rpg/game-core";
+
+export type OverlayMode = "explore" | "dialogue" | "battle";
+export type FieldPromptKind = "idle" | "portal" | "npc" | "encounter" | "dialogue" | "battle";
+export type FieldPromptTone = "neutral" | "accent" | "danger";
+
+export type FieldPrompt = {
+  kind: FieldPromptKind;
+  title: string;
+  body: string;
+  actionLabel: string;
+  tone: FieldPromptTone;
+};
+
+export type BattleReport = {
+  enemyName: string;
+  outcome: NonNullable<BattleResolution["state"]["outcome"]>;
+  title: string;
+  summary: string;
+  lines: string[];
+  turnNumber: number;
+};
+
+export function deriveOverlayMode(params: { battle: unknown; dialogue: unknown }): OverlayMode {
+  if (params.battle) {
+    return "battle";
+  }
+  if (params.dialogue) {
+    return "dialogue";
+  }
+  return "explore";
+}
+
+export function createBattleReport(resolution: BattleResolution): BattleReport | null {
+  const outcome = resolution.state.outcome;
+  if (!resolution.state.finished || !outcome) {
+    return null;
+  }
+
+  const enemyName = resolution.state.enemy.name;
+  const title =
+    outcome === "player_win"
+      ? `${enemyName} 제압`
+      : outcome === "enemy_win"
+        ? `${enemyName}에게 패배`
+        : `${enemyName} 전투 종료`;
+  const summary =
+    outcome === "player_win"
+      ? "보상을 정산하고 다음 탐험으로 이어갈 수 있습니다."
+      : outcome === "enemy_win"
+        ? "부활 후 오버월드 위치와 실시간 씬을 다시 맞췄습니다."
+        : "전투가 무승부로 종료되었습니다.";
+
+  return {
+    enemyName,
+    outcome,
+    title,
+    summary,
+    lines: resolution.logs.slice(-5),
+    turnNumber: Math.max(0, resolution.state.turnNumber - 1),
+  };
+}
+
+export function didSceneChange(world: WorldContent, previousPlayer: PlayerSave, nextPlayer: PlayerSave): boolean {
+  const previousSceneId = world.locations[previousPlayer.locationKey]?.scene.sceneId;
+  const nextSceneId = world.locations[nextPlayer.locationKey]?.scene.sceneId;
+  return Boolean(previousSceneId && nextSceneId && previousSceneId !== nextSceneId);
+}

--- a/apps/web/src/state/store.ts
+++ b/apps/web/src/state/store.ts
@@ -1,4 +1,5 @@
 import type { BattleState, ChatMessage, PlayerSave, PresenceState, WorldContent } from "@rpg/game-core";
+import type { BattleReport, FieldPrompt } from "../gameplay";
 
 export type DialogueState = {
   title: string;
@@ -12,9 +13,11 @@ export type AppState = {
   world: WorldContent | null;
   player: PlayerSave | null;
   battle: BattleState | null;
+  battleReport: BattleReport | null;
   presence: PresenceState[];
   chatMessages: ChatMessage[];
   dialogue: DialogueState | null;
+  fieldPrompt: FieldPrompt | null;
   logs: string[];
   authMode: "login" | "register";
   connectionStatus: "offline" | "connecting" | "online";
@@ -29,9 +32,11 @@ export class AppStore {
     world: null,
     player: null,
     battle: null,
+    battleReport: null,
     presence: [],
     chatMessages: [],
     dialogue: null,
+    fieldPrompt: null,
     logs: [],
     authMode: "login",
     connectionStatus: "offline",

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -275,6 +275,18 @@ button {
   background: rgba(83, 181, 156, 0.18);
 }
 
+.mode-pill.mode-explore {
+  background: rgba(95, 168, 211, 0.18);
+}
+
+.mode-pill.mode-dialogue {
+  background: rgba(83, 181, 156, 0.18);
+}
+
+.mode-pill.mode-battle {
+  background: rgba(216, 109, 96, 0.18);
+}
+
 .pill.muted {
   color: var(--text-muted);
   background: rgba(255, 255, 255, 0.05);
@@ -285,6 +297,36 @@ button {
   grid-template-columns: repeat(6, minmax(0, 1fr));
   gap: 10px;
   margin-top: 16px;
+}
+
+.context-card {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 14px;
+  margin-top: 14px;
+  padding: 14px 16px;
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.context-card.accent {
+  background: rgba(83, 181, 156, 0.12);
+}
+
+.context-card.danger {
+  background: rgba(216, 109, 96, 0.12);
+}
+
+.context-card h3 {
+  margin: 6px 0 0;
+}
+
+.context-card p {
+  margin: 8px 0 0;
+  color: var(--text-muted);
+  line-height: 1.5;
 }
 
 .meter-card,
@@ -417,10 +459,21 @@ button {
   background: rgba(216, 109, 96, 0.15);
 }
 
+.report-card span + span {
+  margin-top: 2px;
+}
+
 .dialogue-line {
   margin: 14px 0 18px;
   font-size: 1.06rem;
   line-height: 1.75;
+}
+
+.dialogue-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
 }
 
 .battle-stats {
@@ -428,6 +481,13 @@ button {
   grid-template-columns: 1fr 1fr;
   gap: 10px;
   margin: 14px 0;
+}
+
+.battle-status-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 14px;
 }
 
 .battle-actions {
@@ -438,9 +498,18 @@ button {
 }
 
 .battle-actions button {
+  display: grid;
+  gap: 6px;
   padding: 12px 14px;
   background: rgba(255, 255, 255, 0.08);
   color: var(--text-main);
+  text-align: left;
+}
+
+.battle-actions button span {
+  color: var(--text-muted);
+  font-family: "Space Mono", monospace;
+  font-size: 0.78rem;
 }
 
 .action-stack {
@@ -459,6 +528,33 @@ button {
   justify-content: space-between;
   align-items: center;
   padding: 11px 14px;
+}
+
+.action-stack button strong {
+  font-size: 0.95rem;
+}
+
+.action-stack button span {
+  color: var(--text-muted);
+  text-align: right;
+}
+
+.action-stack button:disabled {
+  cursor: not-allowed;
+  opacity: 0.42;
+  transform: none;
+}
+
+.battle-feed {
+  margin-top: 16px;
+}
+
+.battle-feed-item {
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text-muted);
+  line-height: 1.5;
 }
 
 .chat-list,
@@ -568,7 +664,9 @@ button {
   .hud-row,
   .dock-header,
   .panel-header,
-  .chat-form {
+  .chat-form,
+  .dialogue-footer,
+  .context-card {
     grid-template-columns: 1fr;
     display: grid;
   }

--- a/apps/web/src/ui/dom.ts
+++ b/apps/web/src/ui/dom.ts
@@ -78,7 +78,7 @@ export class DomUi {
   ): void {
     this.renderAuth(state);
     this.renderHud(state, currentLocation);
-    this.renderActions(state.player, currentLocation, state.battle, equipmentForLocation, skillForLocation, equipped);
+    this.renderActions(state, currentLocation, equipmentForLocation, skillForLocation, equipped);
     this.renderDialogue(state);
     this.renderBattle(state.battle, learnedSkills, learnedTactics);
     this.renderChat(state);
@@ -138,6 +138,8 @@ export class DomUi {
   private renderHud(state: AppState, currentLocation: LocationNode | null): void {
     const nearbyPlayers = state.presence.filter((entry) => entry.username !== state.player?.username);
     const locationTitle = currentLocation ? `${currentLocation.mainLocation} · ${currentLocation.subLocation}` : "월드 로딩 중";
+    const overlayMode = state.battle ? "battle" : state.dialogue ? "dialogue" : "explore";
+    const prompt = state.fieldPrompt;
 
     this.hudPanel.innerHTML = `
       <div class="hud-row">
@@ -148,12 +150,23 @@ export class DomUi {
         </div>
         <div class="hud-meta">
           <span class="status-pill ${state.connectionStatus}">${state.connectionStatus}</span>
+          <span class="status-pill mode-pill mode-${overlayMode}">${overlayMode}</span>
           <button class="ghost" data-save ${state.player ? "" : "disabled"}>저장</button>
         </div>
       </div>
       <div class="meter-grid">
         ${state.player ? this.renderPlayerMeters(state.player, nearbyPlayers.length) : this.renderLoadingMeters(state)}
       </div>
+      ${prompt ? `
+        <div class="context-card ${prompt.tone}">
+          <div>
+            <div class="eyebrow">FIELD PROMPT</div>
+            <h3>${prompt.title}</h3>
+            <p>${prompt.body}</p>
+          </div>
+          <span class="pill">${prompt.actionLabel}</span>
+        </div>
+      ` : ""}
     `;
 
     const saveButton = this.hudPanel.querySelector<HTMLButtonElement>("[data-save]");
@@ -163,13 +176,13 @@ export class DomUi {
   }
 
   private renderActions(
-    player: PlayerSave | null,
+    state: AppState,
     currentLocation: LocationNode | null,
-    battle: BattleState | null,
     equipmentForLocation: EquipmentDefinition[],
     skillsForLocation: SkillDefinition[],
     equipped: EquipmentDefinition[],
   ): void {
+    const { player, battle, battleReport } = state;
     if (!player || !currentLocation) {
       this.actionPanel.classList.remove("visible");
       this.actionPanel.innerHTML = "";
@@ -223,6 +236,13 @@ export class DomUi {
         ${skillButtons}
         ${!hasContextActions ? `<div class="dock-card static"><strong>탐험 구간</strong><span>출구 진입 후 Enter 로 씬 전환, NPC 근처에서 Space 로 대화</span></div>` : ""}
         ${battle ? `<div class="dock-card static danger"><strong>전투 진행 중</strong><span>오른쪽 전투 오버레이에서 행동을 선택하세요.</span></div>` : ""}
+        ${battleReport ? `
+          <div class="dock-card static ${battleReport.outcome === "enemy_win" ? "danger" : "accent"} report-card">
+            <strong>${battleReport.title}</strong>
+            <span>${battleReport.summary}</span>
+            <span>최근 전투 로그 ${battleReport.lines.length}개가 오른쪽 패널에 반영되었습니다.</span>
+          </div>
+        ` : ""}
       </div>
     `;
 
@@ -257,7 +277,10 @@ export class DomUi {
         <span>${state.dialogue.index + 1} / ${state.dialogue.lines.length}</span>
       </div>
       <p class="dialogue-line">${currentLine}</p>
-      <button class="primary" data-dialogue-next>${state.dialogue.index >= state.dialogue.lines.length - 1 ? "닫기" : "다음"}</button>
+      <div class="dialogue-footer">
+        <p class="panel-note">Space 또는 Enter 로 계속 진행할 수 있습니다.</p>
+        <button class="primary" data-dialogue-next>${state.dialogue.index >= state.dialogue.lines.length - 1 ? "닫기" : "다음"}</button>
+      </div>
     `;
     (this.dialoguePanel.querySelector("[data-dialogue-next]") as HTMLButtonElement).onclick = () => this.callbacks.onDialogueNext();
   }
@@ -268,6 +291,12 @@ export class DomUi {
       this.battlePanel.innerHTML = "";
       return;
     }
+
+    const statuses = [
+      battle.charged ? "충전 완료" : null,
+      battle.evadeNext ? "다음 반격 회피 준비" : null,
+      battle.guardBreakTurns > 0 ? `가드 브레이크 ${battle.guardBreakTurns}턴` : null,
+    ].filter((entry): entry is string => Boolean(entry));
 
     this.battlePanel.classList.add("visible");
     this.battlePanel.innerHTML = `
@@ -282,18 +311,35 @@ export class DomUi {
         <div><span>내 MP</span><strong>${Math.round(battle.player.currentMp)} / ${battle.player.maxMp}</strong></div>
         <div><span>전황</span><strong>${battle.isBoss ? "보스전" : "일반전"}</strong></div>
       </div>
+      <div class="battle-status-strip">
+        ${statuses.map((status) => `<span class="pill">${status}</span>`).join("") || `<span class="pill muted">지속 효과 없음</span>`}
+      </div>
       <div class="battle-actions">
-        <button data-battle-basic="attack">공격</button>
-        <button data-battle-basic="normal">일반</button>
-        <button data-battle-basic="defend">방어</button>
+        <button data-battle-basic="attack"><strong>공격</strong><span>1</span></button>
+        <button data-battle-basic="normal"><strong>일반</strong><span>2</span></button>
+        <button data-battle-basic="defend"><strong>방어</strong><span>3</span></button>
       </div>
       <div class="action-stack">
         <h3>특수 기술</h3>
-        ${skills.map((skill) => `<button data-battle-skill="${skill.id}">${skill.name}<span>MP ${skill.manaCost}</span></button>`).join("") || `<p class="panel-note">습득한 기술이 없습니다.</p>`}
+        ${skills.map((skill) => `
+          <button data-battle-skill="${skill.id}" ${battle.player.currentMp < skill.manaCost ? "disabled" : ""}>
+            <strong>${skill.name}</strong>
+            <span>MP ${skill.manaCost}</span>
+          </button>
+        `).join("") || `<p class="panel-note">습득한 기술이 없습니다.</p>`}
       </div>
       <div class="action-stack">
         <h3>전술</h3>
-        ${tactics.map((tactic) => `<button data-battle-tactic="${tactic.id}">${tactic.name}</button>`).join("") || `<p class="panel-note">습득한 전술이 없습니다.</p>`}
+        ${tactics.map((tactic) => `
+          <button data-battle-tactic="${tactic.id}">
+            <strong>${tactic.name}</strong>
+            <span>${tactic.description}</span>
+          </button>
+        `).join("") || `<p class="panel-note">습득한 전술이 없습니다.</p>`}
+      </div>
+      <div class="action-stack battle-feed">
+        <h3>최근 전황</h3>
+        ${battle.log.slice(-6).map((entry) => `<div class="battle-feed-item">${entry}</div>`).join("")}
       </div>
     `;
 

--- a/apps/web/test/gameplay.test.ts
+++ b/apps/web/test/gameplay.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { createBattle, createStarterPlayer, performBattleAction, type LocationNode, type WorldContent } from "@rpg/game-core";
+import { createBattleReport, deriveOverlayMode, didSceneChange } from "../src/gameplay";
+
+const baseWorld: WorldContent = {
+  startLocationKey: "시작의 마을::여관",
+  locations: {},
+  equipment: [],
+  skills: [],
+  tactics: [],
+  enemies: {},
+  enemiesByLocation: {},
+};
+
+function makeLocation(key: string, sceneId: string): LocationNode {
+  const [mainLocation = "테스트 마을", subLocation = "테스트 구역"] = key.split("::");
+  return {
+    key,
+    mainLocation,
+    subLocation,
+    story: [],
+    connections: [],
+    scene: {
+      sceneId,
+      themeId: "village",
+      width: 1024,
+      height: 768,
+      tileSize: 32,
+      backgroundColor: "#10231b",
+      spawn: { x: 120, y: 120 },
+      portals: [],
+      npcs: [],
+      encounterZones: [],
+      collisionZones: [],
+      assets: {
+        layoutId: "inn",
+        mapJsonPath: "/maps/test.json",
+        terrainTexturePath: "/terrain.svg",
+        propsTexturePath: "/props.svg",
+        playerTexturePath: "/player.svg",
+        remotePlayerTexturePath: "/remote.svg",
+        npcTexturePath: "/npc.svg",
+        portalTexturePath: "/portal.svg",
+        encounterTexturePath: "/encounter.svg",
+        license: "placeholder",
+        attribution: "test",
+      },
+    },
+  };
+}
+
+describe("web gameplay helpers", () => {
+  it("derives overlay mode with battle priority", () => {
+    expect(deriveOverlayMode({ battle: null, dialogue: null })).toBe("explore");
+    expect(deriveOverlayMode({ battle: null, dialogue: { title: "npc" } })).toBe("dialogue");
+    expect(deriveOverlayMode({ battle: { id: "battle-1" }, dialogue: { title: "npc" } })).toBe("battle");
+  });
+
+  it("builds a concise battle report after victory", () => {
+    const player = createStarterPlayer("tester", baseWorld);
+    const enemy = {
+      id: "enemy-slime",
+      name: "슬라임",
+      maxHp: 5,
+      attack: 0,
+      defense: 0,
+      speed: 1,
+      accuracy: 0,
+      mana: 0,
+      experienceReward: 4,
+      coinReward: 6,
+    };
+
+    const resolution = performBattleAction({
+      player,
+      state: createBattle(player, enemy),
+      action: { kind: "attack" },
+      skills: {},
+      tactics: {},
+      equipment: {},
+      enemies: { [enemy.id]: enemy },
+      rng: () => 0.5,
+    });
+
+    const report = createBattleReport(resolution);
+
+    expect(report).not.toBeNull();
+    expect(report?.outcome).toBe("player_win");
+    expect(report?.title).toContain("제압");
+    expect(report?.lines.some((entry) => entry.includes("처치"))).toBe(true);
+  });
+
+  it("detects scene changes after defeat relocation", () => {
+    const world: WorldContent = {
+      ...baseWorld,
+      locations: {
+        "시작의 마을::여관": makeLocation("시작의 마을::여관", "inn_scene"),
+        "시작의 마을::필드": makeLocation("시작의 마을::필드", "field_scene"),
+      },
+    };
+
+    const previousPlayer = {
+      ...createStarterPlayer("tester", world),
+      locationKey: "시작의 마을::필드",
+    };
+    const nextPlayer = {
+      ...previousPlayer,
+      locationKey: "시작의 마을::여관",
+    };
+
+    expect(didSceneChange(world, previousPlayer, nextPlayer)).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #5

## 변경 사항
- 오버월드에서 현재 상호작용 대상과 오버레이 잠금 상태를 HUD/필드 프롬프트로 노출
- 대화 중 Space/Enter 진행, 전투 중 숫자키 1/2/3 기본 행동을 지원하도록 입력 흐름 정리
- 전투 패널에 지속 상태, 최근 전황 로그, MP 기반 스킬 비활성화, 전투 종료 요약 카드를 추가
- 전투 패배로 씬이 바뀔 때 presence/chat 상태를 새 씬 기준으로 다시 동기화
- WSL 복사본에서 깨져 있던 pnpm 의존성 링크를 재설치로 정상화하고 웹 헬퍼 테스트를 추가

## 검증
- corepack pnpm typecheck
- corepack pnpm lint
- corepack pnpm test
- corepack pnpm build
