### PR TITLE
feat: 씬 멀티플레이 presence와 재접속 복구 구현

### DIFF
--- a/apps/server/src/content/world.ts
+++ b/apps/server/src/content/world.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import type {
   LegacyBossData,
   LegacyEquipmentData,
@@ -12,9 +13,11 @@ import type {
 import { buildWorldContentFromLegacy } from "@rpg/game-core";
 
 let cachedWorld: WorldContent | null = null;
+const contentDir = dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = resolve(contentDir, "../../../../");
 
 async function readJson<T>(relativePath: string): Promise<T> {
-  const absolutePath = resolve(process.cwd(), relativePath);
+  const absolutePath = resolve(repositoryRoot, relativePath);
   const source = await readFile(absolutePath, "utf8");
   return JSON.parse(source) as T;
 }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,6 +1,7 @@
 import { createAppContext } from "./app";
 import { readEnv } from "./config/env";
 import { createUserRepository } from "./storage";
+import { formatStartupError } from "./startup";
 
 async function main(): Promise<void> {
   const env = readEnv();
@@ -11,13 +12,17 @@ async function main(): Promise<void> {
     repository,
   });
 
+  httpServer.once("error", (error: unknown) => {
+    console.error(`Failed to start RPG server: ${formatStartupError(error, env.port)}`);
+    process.exit(1);
+  });
+
   httpServer.listen(env.port, () => {
     console.log(`RPG server listening on http://localhost:${env.port}`);
   });
 }
 
 main().catch((error: unknown) => {
-  const message = error instanceof Error ? error.message : "Unknown startup error";
-  console.error(`Failed to start RPG server: ${message}`);
+  console.error(`Failed to start RPG server: ${formatStartupError(error, 0)}`);
   process.exit(1);
 });

--- a/apps/server/src/realtime/presence.ts
+++ b/apps/server/src/realtime/presence.ts
@@ -9,6 +9,10 @@ type AuthenticatedSocketData = {
   sceneId?: string;
 };
 
+type PresenceEntry = PresenceState & {
+  socketId: string;
+};
+
 function colorFromUsername(username: string): string {
   const palette = ["#f25f5c", "#247ba0", "#70c1b3", "#ffe066", "#50514f", "#f79d65"];
   const index = Array.from(username).reduce((acc, char) => acc + char.charCodeAt(0), 0) % palette.length;
@@ -16,7 +20,18 @@ function colorFromUsername(username: string): string {
 }
 
 export function configureRealtime(io: Server, env: ServerEnv): void {
-  const presenceByScene = new Map<string, Map<string, PresenceState>>();
+  const presenceByScene = new Map<string, Map<string, PresenceEntry>>();
+
+  const serializeRoom = (room: Map<string, PresenceEntry>): PresenceState[] =>
+    Array.from(room.values()).map((entry) => ({
+      username: entry.username,
+      sceneId: entry.sceneId,
+      x: entry.x,
+      y: entry.y,
+      facing: entry.facing,
+      color: entry.color,
+      updatedAt: entry.updatedAt,
+    }));
 
   io.use((socket, next) => {
     const token = String(socket.handshake.auth.token ?? "");
@@ -47,10 +62,13 @@ export function configureRealtime(io: Server, env: ServerEnv): void {
       socket.leave(currentScene);
       const room = presenceByScene.get(currentScene);
       if (room) {
-        room.delete(data.username);
-        socket.to(currentScene).emit("presence:left", data.username);
-        if (room.size === 0) {
-          presenceByScene.delete(currentScene);
+        const current = room.get(data.username);
+        if (current?.socketId === socket.id) {
+          room.delete(data.username);
+          socket.to(currentScene).emit("presence:left", data.username);
+          if (room.size === 0) {
+            presenceByScene.delete(currentScene);
+          }
         }
       }
       data.sceneId = undefined;
@@ -71,12 +89,16 @@ export function configureRealtime(io: Server, env: ServerEnv): void {
         updatedAt: new Date().toISOString(),
       };
 
-      const room = presenceByScene.get(sceneId) ?? new Map<string, PresenceState>();
-      room.set(data.username, state);
+      const room = presenceByScene.get(sceneId) ?? new Map<string, PresenceEntry>();
+      const hadExisting = room.has(data.username);
+      room.set(data.username, {
+        ...state,
+        socketId: socket.id,
+      });
       presenceByScene.set(sceneId, room);
 
-      socket.emit("presence:snapshot", Array.from(room.values()));
-      socket.to(sceneId).emit("presence:update", state);
+      socket.emit("presence:snapshot", serializeRoom(room));
+      socket.to(sceneId).emit(hadExisting ? "presence:update" : "presence:joined", state);
     };
 
     socket.on("presence:join", (payload: { sceneId: string; x: number; y: number; facing: Facing }) => {
@@ -93,16 +115,25 @@ export function configureRealtime(io: Server, env: ServerEnv): void {
       }
       const room = presenceByScene.get(data.sceneId);
       const current = room?.get(data.username);
-      if (!room || !current) {
+      if (!room || !current || current.socketId !== socket.id) {
         return;
       }
-      const next: PresenceState = {
+      const next: PresenceEntry = {
         ...current,
         ...payload,
         updatedAt: new Date().toISOString(),
+        socketId: socket.id,
       };
       room.set(data.username, next);
-      socket.to(data.sceneId).emit("presence:update", next);
+      socket.to(data.sceneId).emit("presence:update", {
+        username: next.username,
+        sceneId: next.sceneId,
+        x: next.x,
+        y: next.y,
+        facing: next.facing,
+        color: next.color,
+        updatedAt: next.updatedAt,
+      } satisfies PresenceState);
     });
 
     socket.on("chat:send", (payload: { text: string }) => {

--- a/apps/server/src/startup.ts
+++ b/apps/server/src/startup.ts
@@ -1,0 +1,20 @@
+type StartupErrorLike = NodeJS.ErrnoException & {
+  port?: number;
+};
+
+export function formatStartupError(error: unknown, port: number): string {
+  if (typeof error === "object" && error !== null) {
+    const startupError = error as StartupErrorLike;
+    const actualPort = typeof startupError.port === "number" ? startupError.port : port;
+
+    if (startupError.code === "EADDRINUSE") {
+      return `Port ${actualPort} is already in use. Stop the existing server process or change PORT in apps/server/.env before starting a new one.`;
+    }
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return "Unknown startup error";
+}

--- a/apps/server/test/realtime.test.ts
+++ b/apps/server/test/realtime.test.ts
@@ -1,7 +1,7 @@
 import type { AddressInfo } from "node:net";
-import { io as createClient } from "socket.io-client";
+import { io as createClient, type Socket as ClientSocket } from "socket.io-client";
 import { describe, expect, it } from "vitest";
-import type { WorldContent } from "@rpg/game-core";
+import type { PresenceState, WorldContent } from "@rpg/game-core";
 import { createStarterPlayer } from "@rpg/game-core";
 import { createAppContext } from "../src/app";
 import { signToken } from "../src/http/auth";
@@ -19,8 +19,27 @@ function createWorld(): WorldContent {
   };
 }
 
+function onceEvent<T>(socket: ClientSocket, eventName: string): Promise<T> {
+  return new Promise<T>((resolve) => {
+    socket.once(eventName, (payload) => resolve(payload as T));
+  });
+}
+
+async function connectClient(baseUrl: string, token: string): Promise<ClientSocket> {
+  const socket = createClient(baseUrl, { auth: { token } });
+  await new Promise<void>((resolve, reject) => {
+    socket.once("connect", () => resolve());
+    socket.once("connect_error", reject);
+  });
+  return socket;
+}
+
+async function waitForTick(duration = 80): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, duration));
+}
+
 describe("realtime presence", () => {
-  it("shares presence snapshots and chat in the same scene", async () => {
+  it("shares joins, snapshots, chat, and leave events inside the same scene", async () => {
     const repository = new MemoryUserRepository();
     const world = createWorld();
     const env = {
@@ -53,42 +72,117 @@ describe("realtime presence", () => {
     await new Promise<void>((resolve) => context.httpServer.listen(0, resolve));
     const address = context.httpServer.address() as AddressInfo;
     const baseUrl = `http://127.0.0.1:${address.port}`;
-    const tokenA = signToken(env, "hero-a");
-    const tokenB = signToken(env, "hero-b");
 
-    const socketA = createClient(baseUrl, { auth: { token: tokenA } });
-    const socketB = createClient(baseUrl, { auth: { token: tokenB } });
+    const sockets: ClientSocket[] = [];
 
-    await Promise.all([
-      new Promise<void>((resolve, reject) => {
-        socketA.once("connect", () => resolve());
-        socketA.once("connect_error", reject);
-      }),
-      new Promise<void>((resolve, reject) => {
-        socketB.once("connect", () => resolve());
-        socketB.once("connect_error", reject);
-      }),
-    ]);
+    try {
+      const socketA = await connectClient(baseUrl, signToken(env, "hero-a"));
+      const socketB = await connectClient(baseUrl, signToken(env, "hero-b"));
+      sockets.push(socketA, socketB);
 
-    const snapshotPromise = new Promise<unknown[]>((resolve) => {
-      socketB.on("presence:snapshot", (snapshot) => resolve(snapshot));
+      const snapshots: PresenceState[][] = [];
+      const joinedUsers: string[] = [];
+      const chatMessages: string[] = [];
+      const leftUsers: string[] = [];
+
+      socketA.on("presence:snapshot", (snapshot) => snapshots.push(snapshot as PresenceState[]));
+      socketB.on("presence:joined", (presence) => joinedUsers.push((presence as PresenceState).username));
+      socketB.on("chat:message", (message) => chatMessages.push(String((message as { text: string }).text)));
+      socketB.on("presence:left", (username) => leftUsers.push(String(username)));
+
+      socketB.emit("presence:join", { sceneId: "scene-start", x: 50, y: 60, facing: "left" });
+      socketA.emit("presence:join", { sceneId: "scene-start", x: 10, y: 20, facing: "down" });
+      await waitForTick();
+
+      expect(joinedUsers).toContain("hero-a");
+      expect(snapshots.at(-1)?.map((presence) => presence.username).sort()).toEqual(["hero-a", "hero-b"]);
+
+      socketA.emit("chat:send", { text: "안녕!" });
+      await waitForTick();
+      expect(chatMessages).toContain("안녕!");
+
+      socketA.disconnect();
+      await waitForTick();
+      expect(leftUsers).toContain("hero-a");
+    } finally {
+      sockets.forEach((socket) => socket.disconnect());
+      await new Promise<void>((resolve, reject) => context.httpServer.close((error) => (error ? reject(error) : resolve())));
+    }
+  }, 10_000);
+
+  it("keeps the replacement socket active when the same user reconnects", async () => {
+    const repository = new MemoryUserRepository();
+    const world = createWorld();
+    const env = {
+      runtimeMode: "test" as const,
+      port: 0,
+      clientOrigin: "http://localhost:5173",
+      jwtSecret: "0123456789abcdef0123456789abcdef",
+      jwtExpiresIn: "7d",
+      passwordHashRounds: 10,
+      storageDriver: "memory" as const,
+    };
+
+    await repository.saveAccount({
+      username: "hero-a",
+      passwordHash: "plain",
+      player: createStarterPlayer("hero-a", world),
     });
-    const chatPromise = new Promise<{ text: string }>((resolve) => {
-      socketB.on("chat:message", (message) => resolve(message));
+    await repository.saveAccount({
+      username: "hero-b",
+      passwordHash: "plain",
+      player: createStarterPlayer("hero-b", world),
     });
 
-    socketA.emit("presence:join", { sceneId: "scene-start", x: 10, y: 20, facing: "down" });
-    socketB.emit("presence:join", { sceneId: "scene-start", x: 50, y: 60, facing: "left" });
-    socketA.emit("chat:send", { text: "안녕!" });
+    const context = await createAppContext({
+      env,
+      repository,
+      worldLoader: async () => world,
+    });
 
-    const snapshot = await snapshotPromise;
-    const chat = await chatPromise;
+    await new Promise<void>((resolve) => context.httpServer.listen(0, resolve));
+    const address = context.httpServer.address() as AddressInfo;
+    const baseUrl = `http://127.0.0.1:${address.port}`;
 
-    expect(snapshot.length).toBeGreaterThan(0);
-    expect(chat.text).toBe("안녕!");
+    const sockets: ClientSocket[] = [];
 
-    socketA.disconnect();
-    socketB.disconnect();
-    await new Promise<void>((resolve, reject) => context.httpServer.close((error) => (error ? reject(error) : resolve())));
+    try {
+      const observer = await connectClient(baseUrl, signToken(env, "hero-b"));
+      const firstSocket = await connectClient(baseUrl, signToken(env, "hero-a"));
+      sockets.push(observer, firstSocket);
+
+      observer.emit("presence:join", { sceneId: "scene-start", x: 50, y: 60, facing: "left" });
+      firstSocket.emit("presence:join", { sceneId: "scene-start", x: 10, y: 20, facing: "down" });
+      await waitForTick();
+
+      let leftUsername: string | null = null;
+      observer.on("presence:left", (username) => {
+        leftUsername = String(username);
+      });
+
+      const replacementSocket = await connectClient(baseUrl, signToken(env, "hero-a"));
+      sockets.push(replacementSocket);
+
+      const updatePromise = onceEvent<PresenceState>(observer, "presence:update");
+      replacementSocket.emit("presence:join", { sceneId: "scene-start", x: 88, y: 99, facing: "right" });
+      const update = await updatePromise;
+
+      expect(update.username).toBe("hero-a");
+      expect(update.x).toBe(88);
+      expect(update.facing).toBe("right");
+
+      firstSocket.disconnect();
+      await waitForTick();
+      expect(leftUsername).toBeNull();
+
+      const chatPromise = onceEvent<{ text: string }>(observer, "chat:message");
+      replacementSocket.emit("chat:send", { text: "복귀 완료" });
+      const chat = await chatPromise;
+
+      expect(chat.text).toBe("복귀 완료");
+    } finally {
+      sockets.forEach((socket) => socket.disconnect());
+      await new Promise<void>((resolve, reject) => context.httpServer.close((error) => (error ? reject(error) : resolve())));
+    }
   }, 10_000);
 });

--- a/apps/server/test/startup.test.ts
+++ b/apps/server/test/startup.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { formatStartupError } from "../src/startup";
+
+describe("formatStartupError", () => {
+  it("explains port conflicts with a clear next step", () => {
+    const error = Object.assign(new Error("listen EADDRINUSE"), {
+      code: "EADDRINUSE",
+      port: 4000,
+    });
+
+    expect(formatStartupError(error, 4000)).toContain("Port 4000 is already in use.");
+    expect(formatStartupError(error, 4000)).toContain("apps/server/.env");
+  });
+
+  it("falls back to the original error message for unknown failures", () => {
+    expect(formatStartupError(new Error("boom"), 4000)).toBe("boom");
+  });
+});

--- a/apps/server/test/world.test.ts
+++ b/apps/server/test/world.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { loadWorld, resetWorldCache } from "../src/content/world";
+
+describe("loadWorld", () => {
+  it("loads legacy content from the repository root regardless of current working directory", async () => {
+    resetWorldCache();
+
+    const world = await loadWorld();
+
+    expect(world.startLocationKey).toBeTruthy();
+    expect(Object.keys(world.locations).length).toBeGreaterThan(0);
+    expect(Object.keys(world.enemies).length).toBeGreaterThan(0);
+    expect(world.skills.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/AppController.ts
+++ b/apps/web/src/AppController.ts
@@ -112,16 +112,18 @@ export class AppController {
 
     this.presence = new PresenceClient(import.meta.env.VITE_API_BASE_URL ?? "http://localhost:4000", {
       onSnapshot: (snapshot) => this.setPresence(snapshot),
+      onPresenceJoined: (presence) => this.handlePresenceJoined(presence),
       onPresenceUpdate: (presence) => this.mergePresence(presence),
-      onPresenceLeft: (username) => this.removePresence(username),
+      onPresenceLeft: (username) => this.handlePresenceLeft(username),
       onChatMessage: (message) => {
         this.store.update((state) => ({
           ...state,
           chatMessages: [...state.chatMessages, message].slice(-40),
         }));
       },
-      onConnect: () => this.store.setState({ connectionStatus: "online" }),
-      onDisconnect: () => this.store.setState({ connectionStatus: "offline" }),
+      onConnect: () => this.handleRealtimeConnect(),
+      onDisconnect: (reason) => this.handleRealtimeDisconnect(reason),
+      onConnectError: (message) => this.handleRealtimeConnectError(message),
     });
 
     this.store.subscribe((state) => {
@@ -562,8 +564,59 @@ export class AppController {
     this.store.setState({ connectionStatus: "connecting" });
   }
 
+  private handleRealtimeConnect(): void {
+    const state = this.store.getState();
+    const previousStatus = state.connectionStatus;
+    this.store.setState({ connectionStatus: "online" });
+
+    if (!state.player) {
+      return;
+    }
+
+    if (previousStatus === "offline") {
+      this.store.pushLog("실시간 연결이 복구되었습니다.");
+      return;
+    }
+
+    if (previousStatus === "connecting") {
+      this.store.pushLog("실시간 씬 동기화가 완료되었습니다.");
+    }
+  }
+
+  private handleRealtimeDisconnect(reason: string): void {
+    const state = this.store.getState();
+    const shouldLog = Boolean(state.player && state.connectionStatus !== "offline");
+    this.store.setState({
+      connectionStatus: "offline",
+      presence: [],
+    });
+
+    if (shouldLog) {
+      this.store.pushLog(`실시간 연결이 끊겼습니다. ${reason}`);
+    }
+  }
+
+  private handleRealtimeConnectError(message: string): void {
+    const state = this.store.getState();
+    this.store.setState({
+      connectionStatus: "offline",
+      presence: [],
+    });
+
+    if (state.player) {
+      this.store.pushLog(`실시간 연결 실패: ${message}`);
+    }
+  }
+
   private setPresence(snapshot: PresenceState[]): void {
     this.store.setState({ presence: snapshot });
+  }
+
+  private handlePresenceJoined(presence: PresenceState): void {
+    this.mergePresence(presence);
+    if (presence.username !== this.store.getState().player?.username) {
+      this.store.pushLog(`${presence.username} 님이 현재 씬에 합류했습니다.`);
+    }
   }
 
   private mergePresence(presence: PresenceState): void {
@@ -574,6 +627,14 @@ export class AppController {
         presence: [...existing, presence],
       };
     });
+  }
+
+  private handlePresenceLeft(username: string): void {
+    const selfUsername = this.store.getState().player?.username;
+    this.removePresence(username);
+    if (username !== selfUsername) {
+      this.store.pushLog(`${username} 님이 현재 씬에서 이탈했습니다.`);
+    }
   }
 
   private removePresence(username: string): void {

--- a/apps/web/src/net/socket.ts
+++ b/apps/web/src/net/socket.ts
@@ -1,32 +1,59 @@
 import { io, type Socket } from "socket.io-client";
 import type { ChatMessage, Facing, PresenceState } from "@rpg/game-core";
 
+type PresenceIntent = {
+  sceneId: string;
+  x: number;
+  y: number;
+  facing: Facing;
+};
+
 type RealtimeHandlers = {
   onSnapshot: (snapshot: PresenceState[]) => void;
+  onPresenceJoined: (presence: PresenceState) => void;
   onPresenceUpdate: (presence: PresenceState) => void;
   onPresenceLeft: (username: string) => void;
   onChatMessage: (message: ChatMessage) => void;
   onConnect: () => void;
-  onDisconnect: () => void;
+  onDisconnect: (reason: string) => void;
+  onConnectError: (message: string) => void;
 };
 
 export class PresenceClient {
   private socket: Socket | null = null;
+  private desiredPresence: PresenceIntent | null = null;
+  private isConnected = false;
 
   constructor(
     private readonly baseUrl: string,
     private readonly handlers: RealtimeHandlers,
+    private readonly socketFactory: (baseUrl: string, token: string) => Socket = (baseUrl, token) =>
+      io(baseUrl, {
+        auth: { token },
+      }),
   ) {}
 
   connect(token: string): void {
     this.socket?.disconnect();
-    this.socket = io(this.baseUrl, {
-      auth: { token },
-    });
+    this.desiredPresence = null;
+    this.socket = this.socketFactory(this.baseUrl, token);
+    this.isConnected = false;
 
-    this.socket.on("connect", this.handlers.onConnect);
-    this.socket.on("disconnect", this.handlers.onDisconnect);
+    this.socket.on("connect", () => {
+      this.isConnected = true;
+      this.rejoinCurrentScene();
+      this.handlers.onConnect();
+    });
+    this.socket.on("disconnect", (reason) => {
+      this.isConnected = false;
+      this.handlers.onDisconnect(reason);
+    });
+    this.socket.on("connect_error", (error) => {
+      this.isConnected = false;
+      this.handlers.onConnectError(error.message);
+    });
     this.socket.on("presence:snapshot", this.handlers.onSnapshot);
+    this.socket.on("presence:joined", this.handlers.onPresenceJoined);
     this.socket.on("presence:update", this.handlers.onPresenceUpdate);
     this.socket.on("presence:left", this.handlers.onPresenceLeft);
     this.socket.on("chat:message", this.handlers.onChatMessage);
@@ -35,21 +62,47 @@ export class PresenceClient {
   disconnect(): void {
     this.socket?.disconnect();
     this.socket = null;
+    this.desiredPresence = null;
+    this.isConnected = false;
   }
 
   joinScene(sceneId: string, x: number, y: number, facing: Facing): void {
-    this.socket?.emit("presence:join", { sceneId, x, y, facing });
+    this.desiredPresence = { sceneId, x, y, facing };
+    if (this.isConnected) {
+      this.socket?.emit("presence:join", this.desiredPresence);
+    }
   }
 
   changeScene(sceneId: string, x: number, y: number, facing: Facing): void {
-    this.socket?.emit("scene:change", { sceneId, x, y, facing });
+    this.desiredPresence = { sceneId, x, y, facing };
+    if (this.isConnected) {
+      this.socket?.emit("scene:change", this.desiredPresence);
+    }
   }
 
   updatePosition(x: number, y: number, facing: Facing): void {
-    this.socket?.emit("presence:update", { x, y, facing });
+    if (this.desiredPresence) {
+      this.desiredPresence = {
+        ...this.desiredPresence,
+        x,
+        y,
+        facing,
+      };
+    }
+    if (this.isConnected) {
+      this.socket?.emit("presence:update", { x, y, facing });
+    }
   }
 
   sendChat(text: string): void {
-    this.socket?.emit("chat:send", { text });
+    if (this.isConnected) {
+      this.socket?.emit("chat:send", { text });
+    }
+  }
+
+  private rejoinCurrentScene(): void {
+    if (this.desiredPresence) {
+      this.socket?.emit("presence:join", this.desiredPresence);
+    }
   }
 }

--- a/apps/web/src/ui/dom.ts
+++ b/apps/web/src/ui/dom.ts
@@ -356,6 +356,10 @@ export class DomUi {
 
   private renderChat(state: AppState): void {
     const nearbyPlayers = state.presence.filter((entry) => entry.username !== state.player?.username);
+    const canChat = Boolean(state.player && state.connectionStatus === "online");
+    const chatPlaceholder = state.connectionStatus === "online"
+      ? "같은 씬의 유저에게 말하기"
+      : "연결 복구 후 채팅 가능";
 
     this.chatPanel.innerHTML = `
       <div class="panel-header">
@@ -372,11 +376,11 @@ export class DomUi {
         ${state.chatMessages
           .slice(-8)
           .map((message) => `<div class="chat-item"><strong>${message.username}</strong><span>${message.text}</span></div>`)
-          .join("") || `<p class="panel-note">같은 씬의 유저에게 말을 걸 수 있습니다.</p>`}
+          .join("") || `<p class="panel-note">${state.connectionStatus === "online" ? "같은 씬의 유저에게 말을 걸 수 있습니다." : "실시간 연결이 복구되면 채팅이 다시 활성화됩니다."}</p>`}
       </div>
       <form class="chat-form">
-        <input name="text" placeholder="같은 씬의 유저에게 말하기" ${state.player ? "" : "disabled"} />
-        <button type="submit" class="primary" ${state.player ? "" : "disabled"}>전송</button>
+        <input name="text" placeholder="${chatPlaceholder}" ${canChat ? "" : "disabled"} />
+        <button type="submit" class="primary" ${canChat ? "" : "disabled"}>전송</button>
       </form>
     `;
     const form = this.chatPanel.querySelector(".chat-form") as HTMLFormElement;

--- a/apps/web/test/presenceClient.test.ts
+++ b/apps/web/test/presenceClient.test.ts
@@ -1,0 +1,93 @@
+import type { Socket } from "socket.io-client";
+import { describe, expect, it, vi } from "vitest";
+import { PresenceClient } from "../src/net/socket";
+
+class FakeSocket {
+  private readonly handlers = new Map<string, Array<(...args: unknown[]) => void>>();
+  public readonly emitted: Array<{ eventName: string; payload: unknown }> = [];
+
+  on(eventName: string, handler: (...args: unknown[]) => void): this {
+    const nextHandlers = this.handlers.get(eventName) ?? [];
+    nextHandlers.push(handler);
+    this.handlers.set(eventName, nextHandlers);
+    return this;
+  }
+
+  emit(eventName: string, payload: unknown): this {
+    this.emitted.push({ eventName, payload });
+    return this;
+  }
+
+  disconnect(): this {
+    return this;
+  }
+
+  trigger(eventName: string, ...args: unknown[]): void {
+    (this.handlers.get(eventName) ?? []).forEach((handler) => handler(...args));
+  }
+
+  clearEmitted(): void {
+    this.emitted.length = 0;
+  }
+}
+
+describe("PresenceClient", () => {
+  it("rejoins the latest scene state after reconnect", () => {
+    const socket = new FakeSocket();
+    const onConnect = vi.fn();
+    const onDisconnect = vi.fn();
+
+    const client = new PresenceClient(
+      "http://localhost:4000",
+      {
+        onSnapshot: vi.fn(),
+        onPresenceJoined: vi.fn(),
+        onPresenceUpdate: vi.fn(),
+        onPresenceLeft: vi.fn(),
+        onChatMessage: vi.fn(),
+        onConnect,
+        onDisconnect,
+        onConnectError: vi.fn(),
+      },
+      () => socket as unknown as Socket,
+    );
+
+    client.connect("token-value");
+    client.joinScene("scene-start", 10, 20, "down");
+    expect(socket.emitted).toEqual([]);
+
+    socket.trigger("connect");
+    expect(onConnect).toHaveBeenCalledTimes(1);
+    expect(socket.emitted).toEqual([
+      {
+        eventName: "presence:join",
+        payload: { sceneId: "scene-start", x: 10, y: 20, facing: "down" },
+      },
+    ]);
+
+    socket.clearEmitted();
+    client.updatePosition(14, 28, "left");
+    expect(socket.emitted).toEqual([
+      {
+        eventName: "presence:update",
+        payload: { x: 14, y: 28, facing: "left" },
+      },
+    ]);
+
+    socket.trigger("disconnect", "transport close");
+    expect(onDisconnect).toHaveBeenCalledWith("transport close");
+
+    socket.clearEmitted();
+    client.changeScene("scene-plaza", 120, 220, "up");
+    expect(socket.emitted).toEqual([]);
+
+    socket.trigger("connect");
+    expect(onConnect).toHaveBeenCalledTimes(2);
+    expect(socket.emitted).toEqual([
+      {
+        eventName: "presence:join",
+        payload: { sceneId: "scene-plaza", x: 120, y: 220, facing: "up" },
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #7
Closes #18

## 변경 사항
- 서버 realtime room 상태에 socket 소유권을 붙여 같은 사용자의 재접속 시 stale disconnect 가 새 presence 를 지우지 않도록 정리
- `presence:joined` 이벤트를 추가하고 씬 입장/이탈 로그를 클라이언트 이벤트 피드에 노출
- 클라이언트가 현재 씬/좌표/방향을 기억하고 재연결 시 자동으로 `presence:join` 을 다시 보내도록 보강
- 연결 끊김 시 nearby presence 를 즉시 비우고, 채팅 입력은 온라인 상태에서만 가능하도록 UX 정리
- 서버 realtime 테스트와 웹 PresenceClient 테스트를 추가해 join/leave, 재접속 치환, 자동 재입장을 검증

## 검증
- corepack pnpm --filter @rpg/server test
- corepack pnpm --filter @rpg/web test
- corepack pnpm --filter @rpg/server typecheck
- corepack pnpm --filter @rpg/web typecheck
- corepack pnpm --filter @rpg/server lint
- corepack pnpm --filter @rpg/web lint
- corepack pnpm test
- corepack pnpm typecheck
- corepack pnpm build

## 메모
- 웹 번들 크기 경고는 기존과 동일하게 남아 있으며 `#19`에서 별도로 다룰 예정입니다.
