### PR TITLE
fix: 오버월드 WASD 이동 잠금 흐름 수정

### DIFF
--- a/apps/server/test/api.test.ts
+++ b/apps/server/test/api.test.ts
@@ -17,6 +17,52 @@ function createWorld(): WorldContent {
   };
 }
 
+function createPlayableWorld(): WorldContent {
+  return {
+    startLocationKey: "시작의 마을::마을 입구",
+    locations: {
+      "시작의 마을::마을 입구": {
+        key: "시작의 마을::마을 입구",
+        mainLocation: "시작의 마을",
+        subLocation: "마을 입구",
+        story: [],
+        connections: [],
+        scene: {
+          sceneId: "town_gate",
+          themeId: "village",
+          width: 1024,
+          height: 768,
+          tileSize: 32,
+          backgroundColor: "#10231b",
+          spawn: { x: 512, y: 636 },
+          portals: [],
+          npcs: [],
+          encounterZones: [],
+          collisionZones: [{ id: "center", x: 432, y: 304, width: 160, height: 88 }],
+          assets: {
+            layoutId: "town_gate",
+            mapJsonPath: "/maps/test.json",
+            terrainTexturePath: "/terrain.svg",
+            propsTexturePath: "/props.svg",
+            playerTexturePath: "/player.svg",
+            remotePlayerTexturePath: "/remote.svg",
+            npcTexturePath: "/npc.svg",
+            portalTexturePath: "/portal.svg",
+            encounterTexturePath: "/encounter.svg",
+            license: "placeholder",
+            attribution: "test",
+          },
+        },
+      },
+    },
+    equipment: [],
+    skills: [],
+    tactics: [],
+    enemies: {},
+    enemiesByLocation: {},
+  };
+}
+
 function createEnv() {
   return {
     runtimeMode: "test" as const,
@@ -180,5 +226,40 @@ describe("http api", () => {
         code: "validation_error",
       },
     });
+  });
+
+  it("normalizes a blocked saved position to the scene spawn on player load", async () => {
+    const repository = new MemoryUserRepository();
+    const world = createPlayableWorld();
+    const context = await createAppContext({
+      env: createEnv(),
+      repository,
+      worldLoader: async () => world,
+    });
+
+    const agent = request(context.app);
+    const blockedPlayer = {
+      ...createStarterPlayer("stuck-hero", world),
+      position: { x: 512, y: 384 },
+    };
+
+    await repository.saveAccount({
+      username: "stuck-hero",
+      passwordHash: "secret123",
+      player: blockedPlayer,
+    });
+
+    const login = await agent
+      .post("/auth/login")
+      .send({ username: "stuck-hero", password: "secret123" })
+      .expect(200);
+
+    const loginPayload = login.body as ApiResponse<SessionPayload>;
+    expect(loginPayload.success).toBe(true);
+    if (!loginPayload.success) {
+      throw new Error("login response should be successful");
+    }
+
+    expect(loginPayload.data.player.position).toEqual({ x: 512, y: 636 });
   });
 });

--- a/apps/web/src/AppController.ts
+++ b/apps/web/src/AppController.ts
@@ -429,6 +429,7 @@ export class AppController {
       tactics: this.tacticMap,
       equipment: this.equipmentMap,
       enemies: this.world.enemies,
+      world: this.world,
     });
 
     const previousPlayer = state.player;

--- a/apps/web/src/AppController.ts
+++ b/apps/web/src/AppController.ts
@@ -25,6 +25,12 @@ import { ApiClient } from "./net/api";
 import { PresenceClient } from "./net/socket";
 import { GameBridge } from "./game/GameBridge";
 import { AppStore } from "./state/store";
+import {
+  advanceDialogueProgress,
+  createLocationStoryDialogue,
+  hasUnreadLocationStory,
+  prepareLocationStory,
+} from "./story";
 import { DomUi } from "./ui/dom";
 
 const TOKEN_KEY = "rpg-rebuild-token";
@@ -100,10 +106,19 @@ export class AppController {
         return Boolean(state.player && !state.battle && !state.dialogue);
       },
       getOverlayMode: () => deriveOverlayMode(this.store.getState()),
+      hasPendingLocationStory: () => {
+        const state = this.store.getState();
+        if (!state.player || !state.world) {
+          return false;
+        }
+        const location = state.world.locations[state.player.locationKey] ?? null;
+        return hasUnreadLocationStory(state.player, location);
+      },
       onPositionChange: (x, y, facing) => this.updatePosition(x, y, facing),
       onSceneChange: (locationKey) => {
         void this.changeLocation(locationKey);
       },
+      onOpenLocationStory: () => this.openCurrentLocationStory(),
       onInteractNpc: (npc) => this.openNpcDialogue(npc),
       onEncounter: (zone) => {
         void this.startEncounter(zone);
@@ -172,7 +187,7 @@ export class AppController {
           this.store.setState({ token, player, pending: false, battleReport: null });
           this.presence.connect(token);
           this.enterPresence(player, false);
-          await this.maybeOpenLocationDialogue(player.locationKey);
+          this.syncLocationStoryState(player.locationKey);
           return;
         } catch {
           localStorage.removeItem(TOKEN_KEY);
@@ -237,7 +252,7 @@ export class AppController {
       this.store.pushLog(`${normalizedUsername} ${mode === "login" ? "로그인" : "회원가입"} 성공`);
       this.presence.connect(session.token);
       this.enterPresence(session.player, false);
-      await this.maybeOpenLocationDialogue(session.player.locationKey);
+      this.syncLocationStoryState(session.player.locationKey);
     } catch (error) {
       this.store.setState({ pending: false });
       this.store.pushLog(error instanceof Error ? error.message : "인증 실패");
@@ -289,8 +304,36 @@ export class AppController {
     });
     this.enterPresence(nextPlayer, true);
     this.store.pushLog(`${nextLocation.subLocation}(으)로 이동했습니다.`);
-    await this.maybeOpenLocationDialogue(locationKey);
+    this.syncLocationStoryState(locationKey);
     await this.savePlayer();
+  }
+
+  private openCurrentLocationStory(): void {
+    const state = this.store.getState();
+    if (!state.player || state.battle || state.dialogue) {
+      return;
+    }
+
+    const location = this.world.locations[state.player.locationKey];
+    if (!location) {
+      return;
+    }
+
+    const result = createLocationStoryDialogue(state.player, location);
+    if (state.player !== result.player) {
+      this.store.setState({ player: result.player });
+    }
+
+    if (!result.dialogue) {
+      return;
+    }
+
+    this.store.setState({
+      player: result.player,
+      dialogue: result.dialogue,
+      battleReport: null,
+    });
+    this.store.pushLog(`${result.dialogue.title} 시작`);
   }
 
   private openNpcDialogue(npc: DialogueNpc): void {
@@ -301,6 +344,7 @@ export class AppController {
 
     this.store.setState({
       dialogue: {
+        kind: "npc",
         title: npc.name,
         locationKey: state.player.locationKey,
         lines: npc.lines,
@@ -311,33 +355,23 @@ export class AppController {
     this.store.pushLog(`${npc.name}와(과) 대화를 시작합니다.`);
   }
 
-  private async maybeOpenLocationDialogue(locationKey: string): Promise<void> {
+  private syncLocationStoryState(locationKey: string): boolean {
     const state = this.store.getState();
     if (!state.player) {
-      return;
+      return false;
     }
 
-    const nextPlayer = ensureStoryState(state.player, locationKey);
     const location = this.world.locations[locationKey];
     if (!location) {
-      return;
-    }
-    const story = nextPlayer.storyState[locationKey];
-    if (state.player !== nextPlayer) {
-      this.store.setState({ player: nextPlayer });
+      return false;
     }
 
-    if (story && !story.completed && location.story.length > 0) {
-      this.store.setState({
-        dialogue: {
-          title: `${location.subLocation} 이야기`,
-          locationKey,
-          lines: location.story,
-          index: story.currentIndex,
-        },
-        battleReport: null,
-      });
+    const result = prepareLocationStory(state.player, location);
+    if (state.player !== result.player) {
+      this.store.setState({ player: result.player });
     }
+
+    return result.hasUnreadStory;
   }
 
   private async advanceDialogue(): Promise<void> {
@@ -346,33 +380,20 @@ export class AppController {
       return;
     }
 
-    if (state.dialogue.index < state.dialogue.lines.length - 1) {
-      this.store.setState({
-        dialogue: {
-          ...state.dialogue,
-          index: state.dialogue.index + 1,
-        },
-      });
+    const result = advanceDialogueProgress(state.player, state.dialogue);
+    this.store.setState({
+      player: result.player,
+      dialogue: result.dialogue,
+    });
+
+    if (result.dialogue) {
       return;
     }
 
-    const nextPlayer: PlayerSave = {
-      ...state.player,
-      storyState: {
-        ...state.player.storyState,
-        [state.dialogue.locationKey]: {
-          completed: true,
-          currentIndex: state.dialogue.lines.length - 1,
-        },
-      },
-    };
-
-    this.store.setState({
-      player: nextPlayer,
-      dialogue: null,
-    });
     this.store.pushLog(`${state.dialogue.title} 대화 종료`);
-    await this.savePlayer();
+    if (result.completedLocationStory) {
+      await this.savePlayer();
+    }
   }
 
   private async startEncounter(zone: EncounterZone): Promise<void> {
@@ -441,7 +462,7 @@ export class AppController {
     resolution.logs.slice(-4).forEach((entry) => this.store.pushLog(entry));
     if (sceneChangedAfterBattle) {
       this.enterPresence(nextPlayer, true);
-      await this.maybeOpenLocationDialogue(nextPlayer.locationKey);
+      this.syncLocationStoryState(nextPlayer.locationKey);
     }
     await this.savePlayer();
   }

--- a/apps/web/src/game/GameBridge.ts
+++ b/apps/web/src/game/GameBridge.ts
@@ -9,8 +9,10 @@ import { OverworldScene } from "./OverworldScene";
 type BridgeCallbacks = {
   canMove: () => boolean;
   getOverlayMode: () => OverlayMode;
+  hasPendingLocationStory: () => boolean;
   onPositionChange: (x: number, y: number, facing: Facing) => void;
   onSceneChange: (locationKey: string) => void;
+  onOpenLocationStory: () => void;
   onInteractNpc: (npc: DialogueNpc) => void;
   onEncounter: (zone: EncounterZone) => void;
   onFieldPromptChange: (prompt: FieldPrompt) => void;

--- a/apps/web/src/game/OverworldScene.ts
+++ b/apps/web/src/game/OverworldScene.ts
@@ -13,8 +13,10 @@ import type { FieldPrompt, OverlayMode } from "../gameplay";
 type SceneCallbacks = {
   canMove: () => boolean;
   getOverlayMode: () => OverlayMode;
+  hasPendingLocationStory: () => boolean;
   onPositionChange: (x: number, y: number, facing: Facing) => void;
   onSceneChange: (locationKey: string) => void;
+  onOpenLocationStory: () => void;
   onInteractNpc: (npc: DialogueNpc) => void;
   onEncounter: (zone: EncounterZone) => void;
   onFieldPromptChange: (prompt: FieldPrompt) => void;
@@ -204,8 +206,10 @@ export class OverworldScene extends Phaser.Scene {
     const activePortal = this.findActivePortal(nextX, nextY);
     const activeNpc = this.findActiveNpc(nextX, nextY);
     const activeEncounter = this.findActiveEncounter(nextX, nextY);
+    const hasPendingLocationStory = this.callbacks.hasPendingLocationStory();
     const prompt = this.resolvePrompt({
       overlayMode,
+      hasPendingLocationStory,
       portal: activePortal,
       npc: activeNpc?.npc ?? null,
       encounter: activeEncounter?.data ?? null,
@@ -221,6 +225,13 @@ export class OverworldScene extends Phaser.Scene {
     if (activePortal && Phaser.Input.Keyboard.JustDown(this.keyEnter)) {
       this.callbacks.onSceneChange(activePortal.locationKey);
       return;
+    }
+
+    if (!activePortal && !activeNpc && hasPendingLocationStory) {
+      if (Phaser.Input.Keyboard.JustDown(this.keySpace) || Phaser.Input.Keyboard.JustDown(this.keyEnter)) {
+        this.callbacks.onOpenLocationStory();
+        return;
+      }
     }
 
     if (activeNpc && Phaser.Input.Keyboard.JustDown(this.keySpace)) {
@@ -391,6 +402,7 @@ export class OverworldScene extends Phaser.Scene {
 
   private resolvePrompt(params: {
     overlayMode: OverlayMode;
+    hasPendingLocationStory: boolean;
     portal: { label: string } | null;
     npc: DialogueNpc | null;
     encounter: EncounterZone | null;
@@ -421,6 +433,16 @@ export class OverworldScene extends Phaser.Scene {
         title: `${params.portal.label} 이동 준비`,
         body: "출구 위에서 Enter 를 누르면 다음 씬으로 전환됩니다.",
         actionLabel: "Enter",
+        tone: "accent",
+      };
+    }
+
+    if (params.hasPendingLocationStory) {
+      return {
+        kind: "story",
+        title: "지역 이야기 확인 가능",
+        body: "이 지역의 도입 대사를 아직 읽지 않았습니다. Space 또는 Enter 로 바로 열 수 있습니다.",
+        actionLabel: "Space / Enter",
         tone: "accent",
       };
     }

--- a/apps/web/src/gameplay.ts
+++ b/apps/web/src/gameplay.ts
@@ -1,7 +1,7 @@
 import type { BattleResolution, PlayerSave, WorldContent } from "@rpg/game-core";
 
 export type OverlayMode = "explore" | "dialogue" | "battle";
-export type FieldPromptKind = "idle" | "portal" | "npc" | "encounter" | "dialogue" | "battle";
+export type FieldPromptKind = "idle" | "portal" | "npc" | "encounter" | "dialogue" | "battle" | "story";
 export type FieldPromptTone = "neutral" | "accent" | "danger";
 
 export type FieldPrompt = {

--- a/apps/web/src/state/store.ts
+++ b/apps/web/src/state/store.ts
@@ -2,6 +2,7 @@ import type { BattleState, ChatMessage, PlayerSave, PresenceState, WorldContent 
 import type { BattleReport, FieldPrompt } from "../gameplay";
 
 export type DialogueState = {
+  kind: "location" | "npc";
   title: string;
   locationKey: string;
   lines: string[];

--- a/apps/web/src/story.ts
+++ b/apps/web/src/story.ts
@@ -1,0 +1,94 @@
+import { ensureStoryState, type LocationNode, type PlayerSave } from "@rpg/game-core";
+import type { DialogueState } from "./state/store";
+
+export function hasUnreadLocationStory(
+  player: PlayerSave | null,
+  location: LocationNode | null | undefined,
+): boolean {
+  if (!player || !location || location.story.length === 0) {
+    return false;
+  }
+
+  const story = player.storyState[location.key];
+  return Boolean(story && !story.completed);
+}
+
+export function prepareLocationStory(
+  player: PlayerSave,
+  location: LocationNode | null | undefined,
+): { player: PlayerSave; hasUnreadStory: boolean } {
+  if (!location) {
+    return { player, hasUnreadStory: false };
+  }
+
+  const nextPlayer = ensureStoryState(player, location.key);
+  return {
+    player: nextPlayer,
+    hasUnreadStory: hasUnreadLocationStory(nextPlayer, location),
+  };
+}
+
+export function createLocationStoryDialogue(
+  player: PlayerSave,
+  location: LocationNode | null | undefined,
+): { player: PlayerSave; dialogue: DialogueState | null } {
+  const prepared = prepareLocationStory(player, location);
+  if (!location || !prepared.hasUnreadStory) {
+    return {
+      player: prepared.player,
+      dialogue: null,
+    };
+  }
+
+  const story = prepared.player.storyState[location.key];
+  return {
+    player: prepared.player,
+    dialogue: {
+      kind: "location",
+      title: `${location.subLocation} 이야기`,
+      locationKey: location.key,
+      lines: location.story,
+      index: story?.currentIndex ?? 0,
+    },
+  };
+}
+
+export function advanceDialogueProgress(
+  player: PlayerSave,
+  dialogue: DialogueState,
+): { player: PlayerSave; dialogue: DialogueState | null; completedLocationStory: boolean } {
+  const lastIndex = dialogue.lines.length - 1;
+  if (dialogue.index < lastIndex) {
+    return {
+      player,
+      dialogue: {
+        ...dialogue,
+        index: dialogue.index + 1,
+      },
+      completedLocationStory: false,
+    };
+  }
+
+  if (dialogue.kind !== "location") {
+    return {
+      player,
+      dialogue: null,
+      completedLocationStory: false,
+    };
+  }
+
+  return {
+    player: {
+      ...player,
+      storyState: {
+        ...player.storyState,
+        [dialogue.locationKey]: {
+          completed: true,
+          currentIndex: Math.max(0, lastIndex),
+        },
+      },
+    },
+    dialogue: null,
+    completedLocationStory: true,
+  };
+}

--- a/apps/web/src/ui/dom.ts
+++ b/apps/web/src/ui/dom.ts
@@ -155,7 +155,7 @@ export class DomUi {
         <div class="hud-brand">
           <div class="eyebrow">OVERWORLD MVP</div>
           <h1>${locationTitle}</h1>
-          <p>${state.player ? "WASD 이동 · Space 대화 · Enter 전환 · B 교전" : "접속 후 오버월드 탐험이 활성화됩니다."}</p>
+          <p>${state.player ? "WASD 이동 · Space 상호작용/이야기 · Enter 전환 · B 교전" : "접속 후 오버월드 탐험이 활성화됩니다."}</p>
         </div>
         <div class="hud-meta">
           <span class="status-pill ${state.connectionStatus}">${state.connectionStatus}</span>

--- a/apps/web/test/story.test.ts
+++ b/apps/web/test/story.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { createStarterPlayer, type LocationNode, type WorldContent } from "@rpg/game-core";
+import {
+  advanceDialogueProgress,
+  createLocationStoryDialogue,
+  hasUnreadLocationStory,
+  prepareLocationStory,
+} from "../src/story";
+
+const baseLocation: LocationNode = {
+  key: "시작의 마을::마을 입구",
+  mainLocation: "시작의 마을",
+  subLocation: "마을 입구",
+  story: ["첫 줄", "둘째 줄"],
+  connections: [],
+  scene: {
+    sceneId: "village_gate",
+    themeId: "village",
+    width: 1024,
+    height: 768,
+    tileSize: 32,
+    backgroundColor: "#10231b",
+    spawn: { x: 120, y: 120 },
+    portals: [],
+    npcs: [],
+    encounterZones: [],
+    collisionZones: [],
+    assets: {
+      layoutId: "town_gate",
+      mapJsonPath: "/maps/test.json",
+      terrainTexturePath: "/terrain.svg",
+      propsTexturePath: "/props.svg",
+      playerTexturePath: "/player.svg",
+      remotePlayerTexturePath: "/remote.svg",
+      npcTexturePath: "/npc.svg",
+      portalTexturePath: "/portal.svg",
+      encounterTexturePath: "/encounter.svg",
+      license: "placeholder",
+      attribution: "test",
+    },
+  },
+};
+
+const baseWorld: WorldContent = {
+  startLocationKey: baseLocation.key,
+  locations: {
+    [baseLocation.key]: baseLocation,
+  },
+  equipment: [],
+  skills: [],
+  tactics: [],
+  enemies: {},
+  enemiesByLocation: {},
+};
+
+describe("location story helpers", () => {
+  it("keeps unread location stories available without auto-opening movement locks", () => {
+    const player = createStarterPlayer("tester", baseWorld);
+    const prepared = prepareLocationStory(player, baseLocation);
+
+    expect(prepared.hasUnreadStory).toBe(true);
+    expect(hasUnreadLocationStory(prepared.player, baseLocation)).toBe(true);
+
+    const dialogue = createLocationStoryDialogue(prepared.player, baseLocation);
+    expect(dialogue.dialogue?.kind).toBe("location");
+    expect(dialogue.dialogue?.lines).toEqual(baseLocation.story);
+  });
+
+  it("marks only location stories as completed on the last line", () => {
+    const player = createStarterPlayer("tester", baseWorld);
+    const locationDialogue = createLocationStoryDialogue(player, baseLocation).dialogue;
+    expect(locationDialogue).not.toBeNull();
+
+    const advanced = advanceDialogueProgress(player, {
+      ...locationDialogue!,
+      index: 1,
+    });
+    expect(advanced.completedLocationStory).toBe(true);
+    expect(advanced.dialogue).toBeNull();
+    expect(advanced.player.storyState[baseLocation.key]?.completed).toBe(true);
+
+    const npcAdvanced = advanceDialogueProgress(player, {
+      kind: "npc",
+      title: "이장",
+      locationKey: baseLocation.key,
+      lines: ["안녕"],
+      index: 0,
+    });
+    expect(npcAdvanced.completedLocationStory).toBe(false);
+    expect(npcAdvanced.player.storyState[baseLocation.key]?.completed).toBe(false);
+  });
+});

--- a/packages/game-core/src/engine/battle.ts
+++ b/packages/game-core/src/engine/battle.ts
@@ -10,8 +10,9 @@ import type {
   PlayerSave,
   SkillDefinition,
   TacticDefinition,
+  WorldContent,
 } from "../types";
-import { applyLevelUps, getMaxHp, getMaxMp } from "./player";
+import { applyLevelUps, getMaxHp, getMaxMp, resolveLocationSpawn } from "./player";
 import { clamp, pickRandom, toStableId } from "../utils/id";
 
 function toRuntimePlayer(player: PlayerSave): CombatantRuntime {
@@ -221,6 +222,7 @@ export function performBattleAction(params: {
   tactics: Record<string, TacticDefinition>;
   equipment: Record<string, EquipmentDefinition>;
   enemies: Record<string, EnemyDefinition>;
+  world?: WorldContent;
   rng?: () => number;
 }): BattleResolution {
   const rng = params.rng ?? Math.random;
@@ -403,13 +405,14 @@ export function performBattleAction(params: {
   player = finalizePlayerSnapshot(player, playerRuntime);
 
   if (state.finished && state.outcome === "enemy_win") {
+    const reviveLocationKey = "시작의 마을::여관";
     player = {
       ...player,
       coins: 0,
       currentHp: getMaxHp(player.level),
       currentMp: getMaxMp(player.level),
-      locationKey: "시작의 마을::여관",
-      position: { x: 512, y: 384 },
+      locationKey: reviveLocationKey,
+      position: params.world ? resolveLocationSpawn(params.world, reviveLocationKey) : { x: 512, y: 384 },
     };
     logs.push("패배했습니다. 시작의 마을 여관에서 부활합니다.");
   }

--- a/packages/game-core/src/engine/player.ts
+++ b/packages/game-core/src/engine/player.ts
@@ -26,6 +26,54 @@ export function getMaxMp(level: number): number {
   return maxMp;
 }
 
+function fallbackPosition(): PlayerSave["position"] {
+  return { x: 512, y: 384 };
+}
+
+export function resolveLocationSpawn(world: WorldContent, locationKey: string): PlayerSave["position"] {
+  const location = world.locations[locationKey];
+  return location ? { ...location.scene.spawn } : fallbackPosition();
+}
+
+function isPositionInsideCollision(world: WorldContent, locationKey: string, position: PlayerSave["position"]): boolean {
+  const location = world.locations[locationKey];
+  if (!location) {
+    return false;
+  }
+
+  return location.scene.collisionZones.some((zone) => (
+    position.x >= zone.x
+    && position.x <= zone.x + zone.width
+    && position.y >= zone.y
+    && position.y <= zone.y + zone.height
+  ));
+}
+
+export function normalizePlayerPosition(player: PlayerSave, world: WorldContent): PlayerSave {
+  const location = world.locations[player.locationKey];
+  if (!location) {
+    return player;
+  }
+
+  const position = player.position;
+  const hasValidNumbers = Number.isFinite(position?.x) && Number.isFinite(position?.y);
+  const insideBounds =
+    hasValidNumbers
+    && position.x >= 36
+    && position.x <= location.scene.width - 36
+    && position.y >= 36
+    && position.y <= location.scene.height - 36;
+
+  if (insideBounds && !isPositionInsideCollision(world, player.locationKey, position)) {
+    return player;
+  }
+
+  return {
+    ...player,
+    position: resolveLocationSpawn(world, player.locationKey),
+  };
+}
+
 export function applyLevelUps(player: PlayerSave): { player: PlayerSave; messages: string[] } {
   const nextPlayer: PlayerSave = structuredClone(player);
   const messages: string[] = [];
@@ -51,7 +99,7 @@ export function applyLevelUps(player: PlayerSave): { player: PlayerSave; message
 export function createStarterPlayer(username: string, world: WorldContent): PlayerSave {
   const locationKey = world.startLocationKey || toLocationKey("시작의 마을", "마을 입구");
 
-  return {
+  return normalizePlayerPosition({
     version: 2,
     username,
     coins: 0,
@@ -64,7 +112,7 @@ export function createStarterPlayer(username: string, world: WorldContent): Play
     speed: 10,
     accuracy: 0.8,
     locationKey,
-    position: { x: 512, y: 384 },
+    position: resolveLocationSpawn(world, locationKey),
     facing: "down",
     visitedMainLocations: ["시작의 마을"],
     visitedLocationKeys: [locationKey],
@@ -82,7 +130,7 @@ export function createStarterPlayer(username: string, world: WorldContent): Play
     flags: {
       demonLordDefeated: false,
     },
-  };
+  }, world);
 }
 
 export function ensureStoryState(player: PlayerSave, locationKey: string): PlayerSave {
@@ -112,7 +160,7 @@ export function migrateLegacyPlayerSave(
   }
 
   if (legacy.version === 2) {
-    return legacy as PlayerSave;
+    return normalizePlayerPosition(legacy as PlayerSave, world);
   }
 
   const locationKey = toLocationKey(
@@ -137,7 +185,7 @@ export function migrateLegacyPlayerSave(
     };
   }
 
-  return {
+  return normalizePlayerPosition({
     version: 2,
     username,
     coins: Number(legacy.코인 ?? 0),
@@ -150,7 +198,7 @@ export function migrateLegacyPlayerSave(
     speed: Number(legacy.속도 ?? 10),
     accuracy: Number(legacy.명중률 ?? 0.8),
     locationKey,
-    position: { x: 512, y: 384 },
+    position: resolveLocationSpawn(world, locationKey),
     facing: "down",
     visitedMainLocations: (Array.isArray(legacy.방문) ? legacy.방문 : ["시작의 마을"]).map(String),
     visitedLocationKeys: (Array.isArray(legacy.세부방문) ? legacy.세부방문 : [])
@@ -175,5 +223,5 @@ export function migrateLegacyPlayerSave(
     flags: {
       demonLordDefeated: Boolean(legacy.마왕패배),
     },
-  };
+  }, world);
 }

--- a/packages/game-core/test/battle.test.ts
+++ b/packages/game-core/test/battle.test.ts
@@ -1,9 +1,93 @@
 import { describe, expect, it } from "vitest";
-import { createBattle, createStarterPlayer, performBattleAction, type EffectDefinition, type TacticDefinition } from "../src";
+import {
+  createBattle,
+  createStarterPlayer,
+  migrateLegacyPlayerSave,
+  performBattleAction,
+  type EffectDefinition,
+  type TacticDefinition,
+} from "../src";
 
 const emptyWorld = {
   startLocationKey: "시작의 마을::마을 입구",
   locations: {},
+  equipment: [],
+  skills: [],
+  tactics: [],
+  enemies: {},
+  enemiesByLocation: {},
+};
+
+const overworldWorld = {
+  startLocationKey: "시작의 마을::마을 입구",
+  locations: {
+    "시작의 마을::마을 입구": {
+      key: "시작의 마을::마을 입구",
+      mainLocation: "시작의 마을",
+      subLocation: "마을 입구",
+      story: [],
+      connections: [],
+      scene: {
+        sceneId: "town_gate",
+        themeId: "village" as const,
+        width: 1024,
+        height: 768,
+        tileSize: 32,
+        backgroundColor: "#10231b",
+        spawn: { x: 512, y: 636 },
+        portals: [],
+        npcs: [],
+        encounterZones: [],
+        collisionZones: [{ id: "center", x: 432, y: 304, width: 160, height: 88 }],
+        assets: {
+          layoutId: "town_gate" as const,
+          mapJsonPath: "/maps/test.json",
+          terrainTexturePath: "/terrain.svg",
+          propsTexturePath: "/props.svg",
+          playerTexturePath: "/player.svg",
+          remotePlayerTexturePath: "/remote.svg",
+          npcTexturePath: "/npc.svg",
+          portalTexturePath: "/portal.svg",
+          encounterTexturePath: "/encounter.svg",
+          license: "placeholder" as const,
+          attribution: "test",
+        },
+      },
+    },
+    "시작의 마을::여관": {
+      key: "시작의 마을::여관",
+      mainLocation: "시작의 마을",
+      subLocation: "여관",
+      story: [],
+      connections: [],
+      scene: {
+        sceneId: "inn",
+        themeId: "village" as const,
+        width: 1024,
+        height: 768,
+        tileSize: 32,
+        backgroundColor: "#10231b",
+        spawn: { x: 512, y: 640 },
+        portals: [],
+        npcs: [],
+        encounterZones: [],
+        collisionZones: [],
+        assets: {
+          layoutId: "inn" as const,
+          mapJsonPath: "/maps/test.json",
+          terrainTexturePath: "/terrain.svg",
+          propsTexturePath: "/props.svg",
+          playerTexturePath: "/player.svg",
+          remotePlayerTexturePath: "/remote.svg",
+          npcTexturePath: "/npc.svg",
+          portalTexturePath: "/portal.svg",
+          encounterTexturePath: "/encounter.svg",
+          license: "placeholder" as const,
+          attribution: "test",
+        },
+      },
+    },
+  },
   equipment: [],
   skills: [],
   tactics: [],
@@ -142,5 +226,53 @@ describe("battle engine", () => {
 
     expect(result.state.enemy.currentHp).toBe(7);
     expect(result.logs.some((entry) => entry.includes("슬라임에게 3 피해"))).toBe(true);
+  });
+
+  it("places starter and revived players on a safe scene spawn", () => {
+    const starter = createStarterPlayer("tester", overworldWorld);
+    expect(starter.position).toEqual({ x: 512, y: 636 });
+
+    const normalizedExisting = migrateLegacyPlayerSave({
+      ...starter,
+      version: 2,
+      position: { x: 512, y: 384 },
+    }, "tester", overworldWorld);
+    expect(normalizedExisting.position).toEqual({ x: 512, y: 636 });
+
+    const defeatedPlayer = {
+      ...starter,
+      currentHp: 1,
+      accuracy: 1,
+      speed: 200,
+      locationKey: "시작의 마을::마을 입구",
+    };
+    const enemy = {
+      id: "enemy-ogre",
+      name: "오우거",
+      maxHp: 999,
+      attack: 999,
+      defense: 0,
+      speed: 99,
+      accuracy: 1,
+      mana: 0,
+      experienceReward: 0,
+      coinReward: 0,
+    };
+
+    const result = performBattleAction({
+      player: defeatedPlayer,
+      state: createBattle(defeatedPlayer, enemy),
+      action: { kind: "attack" },
+      skills: {},
+      tactics: {} as Record<string, TacticDefinition>,
+      equipment: {},
+      enemies: { [enemy.id]: enemy },
+      world: overworldWorld,
+      rng: () => 0.5,
+    });
+
+    expect(result.state.outcome).toBe("enemy_win");
+    expect(result.player.locationKey).toBe("시작의 마을::여관");
+    expect(result.player.position).toEqual({ x: 512, y: 640 });
   });
 });


### PR DESCRIPTION
## Summary
- 씬 진입 직후 지역 스토리를 자동 오픈하지 않고 탐험 중 명시적으로 열도록 변경했습니다
- unread 지역 이야기를 필드 프롬프트로 안내하고, Space 또는 Enter 로 여는 흐름을 추가했습니다
- NPC 대화가 지역 스토리 완료로 잘못 처리되던 부분을 분리하고 회귀 테스트를 추가했습니다

## Testing
- corepack pnpm --filter @rpg/web typecheck
- corepack pnpm --filter @rpg/web test
- corepack pnpm --filter @rpg/web lint
- corepack pnpm --filter @rpg/web build

Closes #27