### PR TITLE
feat: 패널 드래그 리사이즈와 배치 복원 추가

### DIFF
--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -259,6 +259,13 @@ button {
   gap: 10px;
 }
 
+.layout-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
 .status-pill,
 .pill {
   display: inline-flex;

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -122,6 +122,14 @@ button {
   backdrop-filter: blur(16px);
 }
 
+.layout-panel {
+  position: absolute;
+}
+
+.layout-panel.is-dragging {
+  user-select: none;
+}
+
 .hud-panel {
   position: absolute;
   top: 18px;
@@ -586,6 +594,31 @@ button {
   display: grid;
   grid-template-columns: 1fr auto;
   gap: 8px;
+}
+
+@media (min-width: 921px) {
+  .layout-panel.floating-enabled {
+    min-width: var(--panel-min-width, 280px);
+    min-height: var(--panel-min-height, 160px);
+    overflow: auto;
+    overscroll-behavior: contain;
+    resize: both;
+    cursor: grab;
+  }
+
+  .layout-panel.floating-enabled.is-dragging {
+    cursor: grabbing;
+  }
+
+  .layout-panel.floating-enabled button,
+  .layout-panel.floating-enabled [role="button"] {
+    cursor: pointer;
+  }
+
+  .layout-panel.floating-enabled input,
+  .layout-panel.floating-enabled textarea {
+    cursor: text;
+  }
 }
 
 @media (max-width: 1180px) {

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -122,6 +122,63 @@ button {
   backdrop-filter: blur(16px);
 }
 
+.panel-shell {
+  display: grid;
+  gap: 14px;
+}
+
+.panel-shell-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.panel-shell-copy {
+  min-width: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.panel-shell-heading h1,
+.panel-shell-heading h2 {
+  margin: 0;
+}
+
+.panel-shell-heading h1 {
+  font-size: clamp(1.25rem, 2.2vw, 1.8rem);
+}
+
+.panel-shell-subtitle {
+  margin: 6px 0 0;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.panel-shell-controls {
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.panel-shell-body {
+  min-width: 0;
+}
+
+.panel.is-collapsed .panel-shell {
+  gap: 0;
+}
+
+.panel.is-collapsed .panel-shell-body {
+  display: none;
+}
+
+.panel-toggle-button {
+  white-space: nowrap;
+}
+
 .layout-panel {
   position: absolute;
 }
@@ -216,18 +273,12 @@ button {
   gap: 14px;
 }
 
-.hud-brand h1,
 .auth-card h2,
 .dock-header h2,
 .panel-header h2,
 .panel-header h3 {
   margin: 0;
 }
-
-.hud-brand h1 {
-  font-size: clamp(1.25rem, 2.2vw, 1.8rem);
-}
-
 .hud-brand p,
 .panel-note {
   margin: 6px 0 0;
@@ -626,6 +677,13 @@ button {
   .layout-panel.floating-enabled textarea {
     cursor: text;
   }
+
+  .layout-panel.floating-enabled.is-collapsed {
+    height: auto !important;
+    min-height: 0 !important;
+    overflow: hidden;
+    resize: none;
+  }
 }
 
 @media (max-width: 1180px) {
@@ -701,6 +759,7 @@ button {
 }
 
 @media (max-width: 640px) {
+  .panel-shell-header,
   .hud-row,
   .dock-header,
   .panel-header,
@@ -709,6 +768,10 @@ button {
   .context-card {
     grid-template-columns: 1fr;
     display: grid;
+  }
+
+  .panel-shell-controls {
+    justify-content: start;
   }
 
   .battle-actions,

--- a/apps/web/src/ui/dom.ts
+++ b/apps/web/src/ui/dom.ts
@@ -10,6 +10,7 @@ import { AUTH_PASSWORD_MIN_LENGTH, AUTH_USERNAME_MIN_LENGTH } from "../auth";
 import type { AppState } from "../state/store";
 import {
   clampFloatingPanelLayout,
+  cloneFloatingLayouts,
   FLOATING_LAYOUT_STORAGE_KEY,
   FLOATING_PANEL_CONSTRAINTS,
   isFloatingLayoutEnabled,
@@ -58,6 +59,7 @@ export class DomUi {
   private readonly logPanel: HTMLElement;
   private readonly floatingPanels: Record<FloatingPanelKey, HTMLElement>;
   private panelLayouts: Partial<Record<FloatingPanelKey, FloatingPanelLayout>> = {};
+  private savedPanelLayouts: Partial<Record<FloatingPanelKey, FloatingPanelLayout>> = {};
   private nextPanelZ = 20;
   private activeGesture: LayoutGesture | null = null;
   private readonly handlePointerMove = (event: PointerEvent) => this.onPointerMove(event);
@@ -105,7 +107,8 @@ export class DomUi {
       battle: this.battlePanel,
     };
 
-    this.panelLayouts = this.loadStoredLayouts();
+    this.savedPanelLayouts = this.loadStoredLayouts();
+    this.panelLayouts = cloneFloatingLayouts(this.savedPanelLayouts);
     this.nextPanelZ = this.computeNextPanelZ();
     this.initializeFloatingPanels();
   }
@@ -153,7 +156,7 @@ export class DomUi {
       return;
     }
 
-    window.localStorage.setItem(FLOATING_LAYOUT_STORAGE_KEY, JSON.stringify(this.panelLayouts));
+    window.localStorage.setItem(FLOATING_LAYOUT_STORAGE_KEY, JSON.stringify(this.savedPanelLayouts));
   }
 
   private computeNextPanelZ(): number {
@@ -199,6 +202,24 @@ export class DomUi {
     return clamped;
   }
 
+  private snapshotVisibleLayouts(): void {
+    (Object.keys(this.floatingPanels) as FloatingPanelKey[]).forEach((key) => {
+      const panel = this.floatingPanels[key];
+      if (!panel.classList.contains("visible") && key !== "hud" && key !== "chat" && key !== "log") {
+        return;
+      }
+
+      const measured = this.measurePanelLayout(key);
+      if (!measured) {
+        return;
+      }
+
+      const clamped = this.clampLayout(key, measured);
+      this.panelLayouts[key] = clamped;
+      this.applyLayout(key, clamped);
+    });
+  }
+
   private clampLayout(key: FloatingPanelKey, layout: FloatingPanelLayout): FloatingPanelLayout {
     return clampFloatingPanelLayout(key, layout, {
       width: this.uiLayer.clientWidth,
@@ -208,13 +229,13 @@ export class DomUi {
 
   private applyLayout(key: FloatingPanelKey, layout: FloatingPanelLayout): void {
     const panel = this.floatingPanels[key];
+    panel.style.inset = "";
     panel.style.top = `${layout.y}px`;
     panel.style.left = `${layout.x}px`;
     panel.style.width = `${layout.width}px`;
     panel.style.height = `${layout.height}px`;
     panel.style.right = "auto";
     panel.style.bottom = "auto";
-    panel.style.inset = "auto";
     panel.style.zIndex = String(layout.z);
   }
 
@@ -227,6 +248,10 @@ export class DomUi {
     panel.style.bottom = "";
     panel.style.inset = "";
     panel.style.zIndex = "";
+  }
+
+  private restoreDefaultFloatingLayouts(): void {
+    Object.values(this.floatingPanels).forEach((panel) => this.clearLayoutStyles(panel));
   }
 
   private refreshFloatingLayouts(): void {
@@ -252,7 +277,7 @@ export class DomUi {
       didChange = didChange || JSON.stringify(clamped) !== JSON.stringify(layout);
     });
     if (didChange) {
-      this.persistLayouts();
+      this.panelLayouts = cloneFloatingLayouts(this.panelLayouts);
     }
   }
 
@@ -269,7 +294,6 @@ export class DomUi {
     this.nextPanelZ += 1;
     this.panelLayouts[key] = next;
     this.applyLayout(key, next);
-    this.persistLayouts();
   }
 
   private isInteractiveTarget(target: EventTarget | null): boolean {
@@ -373,19 +397,42 @@ export class DomUi {
         });
         this.panelLayouts[key] = clamped;
         this.applyLayout(key, clamped);
-        this.persistLayouts();
       }
     }
 
     this.activeGesture = null;
   }
 
+  private saveFloatingLayouts(): void {
+    if (!this.isFloatingLayoutActive()) {
+      return;
+    }
+
+    this.snapshotVisibleLayouts();
+    const nextLayouts = cloneFloatingLayouts(this.panelLayouts);
+    this.savedPanelLayouts = nextLayouts;
+    this.persistLayouts();
+  }
+
+  private loadFloatingLayouts(): void {
+    const stored = this.loadStoredLayouts();
+    this.savedPanelLayouts = stored;
+    this.panelLayouts = cloneFloatingLayouts(stored);
+    this.nextPanelZ = this.computeNextPanelZ();
+    if (Object.keys(this.panelLayouts).length === 0) {
+      this.restoreDefaultFloatingLayouts();
+    }
+    this.refreshFloatingLayouts();
+  }
+
   private resetFloatingLayouts(): void {
     this.panelLayouts = {};
+    this.savedPanelLayouts = {};
     this.nextPanelZ = 20;
     if (typeof window !== "undefined") {
       window.localStorage.removeItem(FLOATING_LAYOUT_STORAGE_KEY);
     }
+    this.restoreDefaultFloatingLayouts();
     this.refreshFloatingLayouts();
   }
 
@@ -481,14 +528,18 @@ export class DomUi {
         <div class="hud-meta">
           <span class="status-pill ${state.connectionStatus}">${state.connectionStatus}</span>
           <span class="status-pill mode-pill mode-${overlayMode}">${overlayMode}</span>
-          <button class="ghost" data-reset-layout ${state.player ? "" : "disabled"}>배치 초기화</button>
-          <button class="ghost" data-save ${state.player ? "" : "disabled"}>저장</button>
+          <div class="layout-actions" data-no-panel-drag>
+            <button class="ghost" data-layout-save ${state.player ? "" : "disabled"}>UI 저장</button>
+            <button class="ghost" data-layout-load ${state.player ? "" : "disabled"}>UI 불러오기</button>
+            <button class="ghost" data-reset-layout ${state.player ? "" : "disabled"}>UI 초기화</button>
+          </div>
+          <button class="ghost" data-save ${state.player ? "" : "disabled"}>게임 저장</button>
         </div>
       </div>
       <div class="meter-grid">
         ${state.player ? this.renderPlayerMeters(state.player, nearbyPlayers.length) : this.renderLoadingMeters(state)}
       </div>
-      ${state.player ? `<p class="panel-note">데스크톱에서는 패널 상단을 끌어 이동하고, 오른쪽 아래를 끌어 크기를 조절할 수 있습니다.</p>` : ""}
+      ${state.player ? `<p class="panel-note">데스크톱에서는 패널 상단을 끌어 이동하고, 오른쪽 아래를 끌어 크기를 조절할 수 있습니다. 원하는 배치는 UI 저장으로 보관하고, UI 불러오기로 다시 복원할 수 있습니다.</p>` : ""}
       ${prompt ? `
         <div class="context-card ${prompt.tone}">
           <div>
@@ -504,6 +555,14 @@ export class DomUi {
     const saveButton = this.hudPanel.querySelector<HTMLButtonElement>("[data-save]");
     if (saveButton) {
       saveButton.onclick = () => this.callbacks.onSave();
+    }
+    const layoutSaveButton = this.hudPanel.querySelector<HTMLButtonElement>("[data-layout-save]");
+    if (layoutSaveButton) {
+      layoutSaveButton.onclick = () => this.saveFloatingLayouts();
+    }
+    const layoutLoadButton = this.hudPanel.querySelector<HTMLButtonElement>("[data-layout-load]");
+    if (layoutLoadButton) {
+      layoutLoadButton.onclick = () => this.loadFloatingLayouts();
     }
     const resetLayoutButton = this.hudPanel.querySelector<HTMLButtonElement>("[data-reset-layout]");
     if (resetLayoutButton) {

--- a/apps/web/src/ui/dom.ts
+++ b/apps/web/src/ui/dom.ts
@@ -8,6 +8,15 @@ import type {
 } from "@rpg/game-core";
 import { AUTH_PASSWORD_MIN_LENGTH, AUTH_USERNAME_MIN_LENGTH } from "../auth";
 import type { AppState } from "../state/store";
+import {
+  clampFloatingPanelLayout,
+  FLOATING_LAYOUT_STORAGE_KEY,
+  FLOATING_PANEL_CONSTRAINTS,
+  isFloatingLayoutEnabled,
+  sanitizeStoredLayouts,
+  type FloatingPanelKey,
+  type FloatingPanelLayout,
+} from "./layout";
 
 type UiCallbacks = {
   onAuthSubmit: (mode: "login" | "register", username: string, password: string) => void;
@@ -22,9 +31,24 @@ type UiCallbacks = {
   onSendChat: (text: string) => void;
 };
 
+type LayoutGesture =
+  | {
+    key: FloatingPanelKey;
+    pointerId: number;
+    mode: "move";
+    offsetX: number;
+    offsetY: number;
+  }
+  | {
+    key: FloatingPanelKey;
+    pointerId: number;
+    mode: "resize";
+  };
+
 export class DomUi {
   private readonly root: HTMLElement;
   private readonly appShell: HTMLElement;
+  private readonly uiLayer: HTMLElement;
   private readonly authPanel: HTMLElement;
   private readonly hudPanel: HTMLElement;
   private readonly actionPanel: HTMLElement;
@@ -32,6 +56,15 @@ export class DomUi {
   private readonly battlePanel: HTMLElement;
   private readonly chatPanel: HTMLElement;
   private readonly logPanel: HTMLElement;
+  private readonly floatingPanels: Record<FloatingPanelKey, HTMLElement>;
+  private panelLayouts: Partial<Record<FloatingPanelKey, FloatingPanelLayout>> = {};
+  private nextPanelZ = 20;
+  private activeGesture: LayoutGesture | null = null;
+  private readonly handlePointerMove = (event: PointerEvent) => this.onPointerMove(event);
+  private readonly handlePointerUp = (event: PointerEvent) => this.onPointerUp(event);
+  private readonly handleViewportResize = () => {
+    window.requestAnimationFrame(() => this.refreshFloatingLayouts());
+  };
 
   constructor(root: HTMLElement, private readonly callbacks: UiCallbacks) {
     this.root = root;
@@ -55,6 +88,7 @@ export class DomUi {
     `;
 
     this.appShell = this.root.querySelector(".stage-canvas") as HTMLElement;
+    this.uiLayer = this.root.querySelector(".ui-layer") as HTMLElement;
     this.authPanel = this.root.querySelector(".auth-panel") as HTMLElement;
     this.hudPanel = this.root.querySelector(".hud-panel") as HTMLElement;
     this.actionPanel = this.root.querySelector(".action-panel") as HTMLElement;
@@ -62,10 +96,297 @@ export class DomUi {
     this.battlePanel = this.root.querySelector(".battle-panel") as HTMLElement;
     this.chatPanel = this.root.querySelector(".chat-panel") as HTMLElement;
     this.logPanel = this.root.querySelector(".log-panel") as HTMLElement;
+    this.floatingPanels = {
+      hud: this.hudPanel,
+      log: this.logPanel,
+      chat: this.chatPanel,
+      action: this.actionPanel,
+      dialogue: this.dialoguePanel,
+      battle: this.battlePanel,
+    };
+
+    this.panelLayouts = this.loadStoredLayouts();
+    this.nextPanelZ = this.computeNextPanelZ();
+    this.initializeFloatingPanels();
   }
 
   getGameContainer(): HTMLElement {
     return this.appShell;
+  }
+
+  private initializeFloatingPanels(): void {
+    Object.entries(this.floatingPanels).forEach(([key, panel]) => {
+      const panelKey = key as FloatingPanelKey;
+      const constraint = FLOATING_PANEL_CONSTRAINTS[panelKey];
+      panel.dataset.panelKey = panelKey;
+      panel.classList.add("layout-panel");
+      panel.style.setProperty("--panel-min-width", `${constraint.minWidth}px`);
+      panel.style.setProperty("--panel-min-height", `${constraint.minHeight}px`);
+      panel.addEventListener("pointerdown", (event) => this.onPanelPointerDown(panelKey, event));
+    });
+
+    window.addEventListener("pointermove", this.handlePointerMove);
+    window.addEventListener("pointerup", this.handlePointerUp);
+    window.addEventListener("pointercancel", this.handlePointerUp);
+    window.addEventListener("resize", this.handleViewportResize);
+    window.requestAnimationFrame(() => this.refreshFloatingLayouts());
+  }
+
+  private loadStoredLayouts(): Partial<Record<FloatingPanelKey, FloatingPanelLayout>> {
+    if (typeof window === "undefined") {
+      return {};
+    }
+
+    try {
+      const raw = window.localStorage.getItem(FLOATING_LAYOUT_STORAGE_KEY);
+      if (!raw) {
+        return {};
+      }
+      return sanitizeStoredLayouts(JSON.parse(raw));
+    } catch {
+      return {};
+    }
+  }
+
+  private persistLayouts(): void {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    window.localStorage.setItem(FLOATING_LAYOUT_STORAGE_KEY, JSON.stringify(this.panelLayouts));
+  }
+
+  private computeNextPanelZ(): number {
+    const maxZ = Object.values(this.panelLayouts).reduce((current, layout) => Math.max(current, layout?.z ?? 0), 19);
+    return maxZ + 1;
+  }
+
+  private isFloatingLayoutActive(): boolean {
+    return typeof window !== "undefined" && isFloatingLayoutEnabled(window.innerWidth);
+  }
+
+  private measurePanelLayout(key: FloatingPanelKey): FloatingPanelLayout | null {
+    const panel = this.floatingPanels[key];
+    const panelRect = panel.getBoundingClientRect();
+    const containerRect = this.uiLayer.getBoundingClientRect();
+    if (panelRect.width === 0 || panelRect.height === 0 || containerRect.width === 0 || containerRect.height === 0) {
+      return null;
+    }
+
+    return {
+      x: panelRect.left - containerRect.left,
+      y: panelRect.top - containerRect.top,
+      width: panelRect.width,
+      height: panelRect.height,
+      z: this.panelLayouts[key]?.z ?? this.nextPanelZ,
+    };
+  }
+
+  private ensureMeasuredLayout(key: FloatingPanelKey): FloatingPanelLayout | null {
+    const current = this.panelLayouts[key];
+    if (current) {
+      return current;
+    }
+
+    const measured = this.measurePanelLayout(key);
+    if (!measured) {
+      return null;
+    }
+
+    const clamped = this.clampLayout(key, measured);
+    this.panelLayouts[key] = clamped;
+    this.applyLayout(key, clamped);
+    return clamped;
+  }
+
+  private clampLayout(key: FloatingPanelKey, layout: FloatingPanelLayout): FloatingPanelLayout {
+    return clampFloatingPanelLayout(key, layout, {
+      width: this.uiLayer.clientWidth,
+      height: this.uiLayer.clientHeight,
+    });
+  }
+
+  private applyLayout(key: FloatingPanelKey, layout: FloatingPanelLayout): void {
+    const panel = this.floatingPanels[key];
+    panel.style.top = `${layout.y}px`;
+    panel.style.left = `${layout.x}px`;
+    panel.style.width = `${layout.width}px`;
+    panel.style.height = `${layout.height}px`;
+    panel.style.right = "auto";
+    panel.style.bottom = "auto";
+    panel.style.inset = "auto";
+    panel.style.zIndex = String(layout.z);
+  }
+
+  private clearLayoutStyles(panel: HTMLElement): void {
+    panel.style.top = "";
+    panel.style.left = "";
+    panel.style.width = "";
+    panel.style.height = "";
+    panel.style.right = "";
+    panel.style.bottom = "";
+    panel.style.inset = "";
+    panel.style.zIndex = "";
+  }
+
+  private refreshFloatingLayouts(): void {
+    const enabled = this.isFloatingLayoutActive();
+    Object.values(this.floatingPanels).forEach((panel) => {
+      panel.classList.toggle("floating-enabled", enabled);
+    });
+
+    if (!enabled) {
+      this.activeGesture = null;
+      Object.values(this.floatingPanels).forEach((panel) => {
+        panel.classList.remove("is-dragging", "is-resizing");
+        this.clearLayoutStyles(panel);
+      });
+      return;
+    }
+
+    let didChange = false;
+    (Object.entries(this.panelLayouts) as Array<[FloatingPanelKey, FloatingPanelLayout]>).forEach(([key, layout]) => {
+      const clamped = this.clampLayout(key, layout);
+      this.panelLayouts[key] = clamped;
+      this.applyLayout(key, clamped);
+      didChange = didChange || JSON.stringify(clamped) !== JSON.stringify(layout);
+    });
+    if (didChange) {
+      this.persistLayouts();
+    }
+  }
+
+  private bringPanelToFront(key: FloatingPanelKey): void {
+    const layout = this.ensureMeasuredLayout(key);
+    if (!layout) {
+      return;
+    }
+
+    const next = {
+      ...layout,
+      z: this.nextPanelZ,
+    };
+    this.nextPanelZ += 1;
+    this.panelLayouts[key] = next;
+    this.applyLayout(key, next);
+    this.persistLayouts();
+  }
+
+  private isInteractiveTarget(target: EventTarget | null): boolean {
+    if (!(target instanceof Element)) {
+      return false;
+    }
+
+    return Boolean(target.closest("button, input, textarea, select, option, label, a, [contenteditable='true'], [data-no-panel-drag]"));
+  }
+
+  private isResizeCorner(panel: HTMLElement, event: PointerEvent): boolean {
+    const rect = panel.getBoundingClientRect();
+    return rect.right - event.clientX <= 22 && rect.bottom - event.clientY <= 22;
+  }
+
+  private onPanelPointerDown(key: FloatingPanelKey, event: PointerEvent): void {
+    if (!this.isFloatingLayoutActive()) {
+      return;
+    }
+    if (event.pointerType === "mouse" && event.button !== 0) {
+      return;
+    }
+
+    const panel = this.floatingPanels[key];
+    if (this.isInteractiveTarget(event.target)) {
+      return;
+    }
+
+    const measured = this.ensureMeasuredLayout(key);
+    if (!measured) {
+      return;
+    }
+
+    this.bringPanelToFront(key);
+
+    if (this.isResizeCorner(panel, event)) {
+      this.activeGesture = {
+        key,
+        pointerId: event.pointerId,
+        mode: "resize",
+      };
+      panel.classList.add("is-resizing");
+      return;
+    }
+
+    const panelRect = panel.getBoundingClientRect();
+    const dragZoneHeight = 58;
+    if (event.clientY - panelRect.top > dragZoneHeight) {
+      return;
+    }
+
+    this.activeGesture = {
+      key,
+      pointerId: event.pointerId,
+      mode: "move",
+      offsetX: event.clientX - panelRect.left,
+      offsetY: event.clientY - panelRect.top,
+    };
+    panel.classList.add("is-dragging");
+    panel.setPointerCapture?.(event.pointerId);
+    event.preventDefault();
+  }
+
+  private onPointerMove(event: PointerEvent): void {
+    if (!this.activeGesture || this.activeGesture.mode !== "move" || event.pointerId !== this.activeGesture.pointerId || !this.isFloatingLayoutActive()) {
+      return;
+    }
+
+    const layout = this.panelLayouts[this.activeGesture.key];
+    if (!layout) {
+      return;
+    }
+
+    const containerRect = this.uiLayer.getBoundingClientRect();
+    const next = this.clampLayout(this.activeGesture.key, {
+      ...layout,
+      x: event.clientX - containerRect.left - this.activeGesture.offsetX,
+      y: event.clientY - containerRect.top - this.activeGesture.offsetY,
+    });
+    this.panelLayouts[this.activeGesture.key] = next;
+    this.applyLayout(this.activeGesture.key, next);
+    event.preventDefault();
+  }
+
+  private onPointerUp(event: PointerEvent): void {
+    if (!this.activeGesture || event.pointerId !== this.activeGesture.pointerId) {
+      return;
+    }
+
+    const { key } = this.activeGesture;
+    const panel = this.floatingPanels[key];
+    panel.classList.remove("is-dragging", "is-resizing");
+    panel.releasePointerCapture?.(event.pointerId);
+
+    if (this.isFloatingLayoutActive()) {
+      const measured = this.measurePanelLayout(key);
+      if (measured) {
+        const clamped = this.clampLayout(key, {
+          ...measured,
+          z: this.panelLayouts[key]?.z ?? measured.z,
+        });
+        this.panelLayouts[key] = clamped;
+        this.applyLayout(key, clamped);
+        this.persistLayouts();
+      }
+    }
+
+    this.activeGesture = null;
+  }
+
+  private resetFloatingLayouts(): void {
+    this.panelLayouts = {};
+    this.nextPanelZ = 20;
+    if (typeof window !== "undefined") {
+      window.localStorage.removeItem(FLOATING_LAYOUT_STORAGE_KEY);
+    }
+    this.refreshFloatingLayouts();
   }
 
   render(
@@ -160,12 +481,14 @@ export class DomUi {
         <div class="hud-meta">
           <span class="status-pill ${state.connectionStatus}">${state.connectionStatus}</span>
           <span class="status-pill mode-pill mode-${overlayMode}">${overlayMode}</span>
+          <button class="ghost" data-reset-layout ${state.player ? "" : "disabled"}>배치 초기화</button>
           <button class="ghost" data-save ${state.player ? "" : "disabled"}>저장</button>
         </div>
       </div>
       <div class="meter-grid">
         ${state.player ? this.renderPlayerMeters(state.player, nearbyPlayers.length) : this.renderLoadingMeters(state)}
       </div>
+      ${state.player ? `<p class="panel-note">데스크톱에서는 패널 상단을 끌어 이동하고, 오른쪽 아래를 끌어 크기를 조절할 수 있습니다.</p>` : ""}
       ${prompt ? `
         <div class="context-card ${prompt.tone}">
           <div>
@@ -181,6 +504,10 @@ export class DomUi {
     const saveButton = this.hudPanel.querySelector<HTMLButtonElement>("[data-save]");
     if (saveButton) {
       saveButton.onclick = () => this.callbacks.onSave();
+    }
+    const resetLayoutButton = this.hudPanel.querySelector<HTMLButtonElement>("[data-reset-layout]");
+    if (resetLayoutButton) {
+      resetLayoutButton.onclick = () => this.resetFloatingLayouts();
     }
   }
 

--- a/apps/web/src/ui/dom.ts
+++ b/apps/web/src/ui/dom.ts
@@ -11,10 +11,12 @@ import type { AppState } from "../state/store";
 import {
   clampFloatingPanelLayout,
   cloneFloatingLayouts,
+  cloneCollapsedPanels,
   FLOATING_LAYOUT_STORAGE_KEY,
   FLOATING_PANEL_CONSTRAINTS,
   isFloatingLayoutEnabled,
-  sanitizeStoredLayouts,
+  sanitizeStoredPanelPreferences,
+  type FloatingPanelCollapsedState,
   type FloatingPanelKey,
   type FloatingPanelLayout,
 } from "./layout";
@@ -60,6 +62,8 @@ export class DomUi {
   private readonly floatingPanels: Record<FloatingPanelKey, HTMLElement>;
   private panelLayouts: Partial<Record<FloatingPanelKey, FloatingPanelLayout>> = {};
   private savedPanelLayouts: Partial<Record<FloatingPanelKey, FloatingPanelLayout>> = {};
+  private collapsedPanels: FloatingPanelCollapsedState = {};
+  private savedCollapsedPanels: FloatingPanelCollapsedState = {};
   private nextPanelZ = 20;
   private activeGesture: LayoutGesture | null = null;
   private readonly handlePointerMove = (event: PointerEvent) => this.onPointerMove(event);
@@ -107,8 +111,11 @@ export class DomUi {
       battle: this.battlePanel,
     };
 
-    this.savedPanelLayouts = this.loadStoredLayouts();
-    this.panelLayouts = cloneFloatingLayouts(this.savedPanelLayouts);
+    const storedPreferences = this.loadStoredPreferences();
+    this.savedPanelLayouts = storedPreferences.layouts;
+    this.panelLayouts = cloneFloatingLayouts(storedPreferences.layouts);
+    this.savedCollapsedPanels = storedPreferences.collapsed;
+    this.collapsedPanels = cloneCollapsedPanels(storedPreferences.collapsed);
     this.nextPanelZ = this.computeNextPanelZ();
     this.initializeFloatingPanels();
   }
@@ -135,28 +142,43 @@ export class DomUi {
     window.requestAnimationFrame(() => this.refreshFloatingLayouts());
   }
 
-  private loadStoredLayouts(): Partial<Record<FloatingPanelKey, FloatingPanelLayout>> {
+  private loadStoredPreferences(): {
+    layouts: Partial<Record<FloatingPanelKey, FloatingPanelLayout>>;
+    collapsed: FloatingPanelCollapsedState;
+  } {
     if (typeof window === "undefined") {
-      return {};
+      return {
+        layouts: {},
+        collapsed: {},
+      };
     }
 
     try {
       const raw = window.localStorage.getItem(FLOATING_LAYOUT_STORAGE_KEY);
       if (!raw) {
-        return {};
+        return {
+          layouts: {},
+          collapsed: {},
+        };
       }
-      return sanitizeStoredLayouts(JSON.parse(raw));
+      return sanitizeStoredPanelPreferences(JSON.parse(raw));
     } catch {
-      return {};
+      return {
+        layouts: {},
+        collapsed: {},
+      };
     }
   }
 
-  private persistLayouts(): void {
+  private persistPreferences(): void {
     if (typeof window === "undefined") {
       return;
     }
 
-    window.localStorage.setItem(FLOATING_LAYOUT_STORAGE_KEY, JSON.stringify(this.savedPanelLayouts));
+    window.localStorage.setItem(FLOATING_LAYOUT_STORAGE_KEY, JSON.stringify({
+      layouts: this.savedPanelLayouts,
+      collapsed: this.savedCollapsedPanels,
+    }));
   }
 
   private computeNextPanelZ(): number {
@@ -214,7 +236,10 @@ export class DomUi {
         return;
       }
 
-      const clamped = this.clampLayout(key, measured);
+      const clamped = this.clampLayout(key, {
+        ...measured,
+        height: this.collapsedPanels[key] ? (this.panelLayouts[key]?.height ?? measured.height) : measured.height,
+      });
       this.panelLayouts[key] = clamped;
       this.applyLayout(key, clamped);
     });
@@ -411,29 +436,117 @@ export class DomUi {
     this.snapshotVisibleLayouts();
     const nextLayouts = cloneFloatingLayouts(this.panelLayouts);
     this.savedPanelLayouts = nextLayouts;
-    this.persistLayouts();
+    this.savedCollapsedPanels = cloneCollapsedPanels(this.collapsedPanels);
+    this.persistPreferences();
   }
 
   private loadFloatingLayouts(): void {
-    const stored = this.loadStoredLayouts();
-    this.savedPanelLayouts = stored;
-    this.panelLayouts = cloneFloatingLayouts(stored);
+    const stored = this.loadStoredPreferences();
+    this.savedPanelLayouts = stored.layouts;
+    this.panelLayouts = cloneFloatingLayouts(stored.layouts);
+    this.savedCollapsedPanels = cloneCollapsedPanels(stored.collapsed);
+    this.collapsedPanels = cloneCollapsedPanels(stored.collapsed);
     this.nextPanelZ = this.computeNextPanelZ();
     if (Object.keys(this.panelLayouts).length === 0) {
       this.restoreDefaultFloatingLayouts();
     }
     this.refreshFloatingLayouts();
+    this.syncCollapsedPanels();
   }
 
   private resetFloatingLayouts(): void {
     this.panelLayouts = {};
     this.savedPanelLayouts = {};
+    this.collapsedPanels = {};
+    this.savedCollapsedPanels = {};
     this.nextPanelZ = 20;
     if (typeof window !== "undefined") {
       window.localStorage.removeItem(FLOATING_LAYOUT_STORAGE_KEY);
     }
     this.restoreDefaultFloatingLayouts();
     this.refreshFloatingLayouts();
+    this.syncCollapsedPanels();
+  }
+
+  private isPanelCollapsed(key: FloatingPanelKey): boolean {
+    return Boolean(this.collapsedPanels[key]);
+  }
+
+  private togglePanelCollapsed(key: FloatingPanelKey): void {
+    this.collapsedPanels[key] = !this.isPanelCollapsed(key);
+    this.syncCollapsedPanel(key);
+  }
+
+  private syncCollapsedPanels(): void {
+    (Object.keys(this.floatingPanels) as FloatingPanelKey[]).forEach((key) => {
+      this.syncCollapsedPanel(key);
+    });
+  }
+
+  private syncCollapsedPanel(key: FloatingPanelKey): void {
+    const panel = this.floatingPanels[key];
+    const collapsed = this.isPanelCollapsed(key);
+    panel.classList.toggle("is-collapsed", collapsed);
+
+    const toggleButton = panel.querySelector<HTMLButtonElement>("[data-panel-toggle]");
+    if (toggleButton) {
+      const title = toggleButton.dataset.panelTitle ?? "패널";
+      toggleButton.textContent = collapsed ? "펼치기" : "접기";
+      toggleButton.setAttribute("aria-expanded", String(!collapsed));
+      toggleButton.setAttribute("aria-label", collapsed ? `${title} 패널 펼치기` : `${title} 패널 접기`);
+    }
+  }
+
+  private bindPanelToggle(key: FloatingPanelKey): void {
+    const panel = this.floatingPanels[key];
+    const toggleButton = panel.querySelector<HTMLButtonElement>("[data-panel-toggle]");
+    if (!toggleButton) {
+      return;
+    }
+
+    toggleButton.onclick = () => this.togglePanelCollapsed(key);
+    this.syncCollapsedPanel(key);
+  }
+
+  private renderPanelFrame(options: {
+    key: FloatingPanelKey;
+    eyebrow: string;
+    title: string;
+    titleTag?: "h1" | "h2";
+    subtitle?: string;
+    controls?: string;
+    body: string;
+    bodyClassName?: string;
+  }): string {
+    const headingTag = options.titleTag ?? "h2";
+
+    return `
+      <div class="panel-shell">
+        <div class="panel-shell-header">
+          <div class="panel-shell-copy">
+            <div class="eyebrow">${options.eyebrow}</div>
+            <div class="panel-shell-heading">
+              <${headingTag}>${options.title}</${headingTag}>
+              ${options.subtitle ? `<p class="panel-shell-subtitle">${options.subtitle}</p>` : ""}
+            </div>
+          </div>
+          <div class="panel-shell-controls" data-no-panel-drag>
+            ${options.controls ?? ""}
+            <button
+              class="ghost panel-toggle-button"
+              type="button"
+              data-panel-toggle
+              data-panel-title="${options.title}"
+            >
+              ${this.isPanelCollapsed(options.key) ? "펼치기" : "접기"}
+            </button>
+          </div>
+        </div>
+        <div class="panel-shell-body ${options.bodyClassName ?? ""}">
+          ${options.body}
+        </div>
+      </div>
+    `;
   }
 
   render(
@@ -517,25 +630,17 @@ export class DomUi {
     const locationTitle = currentLocation ? `${currentLocation.mainLocation} · ${currentLocation.subLocation}` : "월드 로딩 중";
     const overlayMode = state.battle ? "battle" : state.dialogue ? "dialogue" : "explore";
     const prompt = state.fieldPrompt;
-
-    this.hudPanel.innerHTML = `
-      <div class="hud-row">
-        <div class="hud-brand">
-          <div class="eyebrow">OVERWORLD MVP</div>
-          <h1>${locationTitle}</h1>
-          <p>${state.player ? "WASD 이동 · Space 상호작용/이야기 · Enter 전환 · B 교전" : "접속 후 오버월드 탐험이 활성화됩니다."}</p>
-        </div>
-        <div class="hud-meta">
-          <span class="status-pill ${state.connectionStatus}">${state.connectionStatus}</span>
-          <span class="status-pill mode-pill mode-${overlayMode}">${overlayMode}</span>
-          <div class="layout-actions" data-no-panel-drag>
-            <button class="ghost" data-layout-save ${state.player ? "" : "disabled"}>UI 저장</button>
-            <button class="ghost" data-layout-load ${state.player ? "" : "disabled"}>UI 불러오기</button>
-            <button class="ghost" data-reset-layout ${state.player ? "" : "disabled"}>UI 초기화</button>
-          </div>
-          <button class="ghost" data-save ${state.player ? "" : "disabled"}>게임 저장</button>
-        </div>
+    const controls = `
+      <span class="status-pill ${state.connectionStatus}">${state.connectionStatus}</span>
+      <span class="status-pill mode-pill mode-${overlayMode}">${overlayMode}</span>
+      <div class="layout-actions">
+        <button class="ghost" data-layout-save ${state.player ? "" : "disabled"}>UI 저장</button>
+        <button class="ghost" data-layout-load ${state.player ? "" : "disabled"}>UI 불러오기</button>
+        <button class="ghost" data-reset-layout ${state.player ? "" : "disabled"}>UI 초기화</button>
       </div>
+      <button class="ghost" data-save ${state.player ? "" : "disabled"}>게임 저장</button>
+    `;
+    const body = `
       <div class="meter-grid">
         ${state.player ? this.renderPlayerMeters(state.player, nearbyPlayers.length) : this.renderLoadingMeters(state)}
       </div>
@@ -551,6 +656,16 @@ export class DomUi {
         </div>
       ` : ""}
     `;
+
+    this.hudPanel.innerHTML = this.renderPanelFrame({
+      key: "hud",
+      eyebrow: "OVERWORLD MVP",
+      title: locationTitle,
+      titleTag: "h1",
+      subtitle: state.player ? "WASD 이동 · Space 상호작용/이야기 · Enter 전환 · B 교전" : "접속 후 오버월드 탐험이 활성화됩니다.",
+      controls,
+      body,
+    });
 
     const saveButton = this.hudPanel.querySelector<HTMLButtonElement>("[data-save]");
     if (saveButton) {
@@ -568,6 +683,7 @@ export class DomUi {
     if (resetLayoutButton) {
       resetLayoutButton.onclick = () => this.resetFloatingLayouts();
     }
+    this.bindPanelToggle("hud");
   }
 
   private renderActions(
@@ -614,32 +730,33 @@ export class DomUi {
 
     const hasContextActions = restingVisible || equipmentButtons || skillButtons;
     this.actionPanel.classList.add("visible");
-    this.actionPanel.innerHTML = `
-      <div class="dock-header">
-        <div>
-          <div class="eyebrow">FIELD ACTIONS</div>
-          <h2>${currentLocation.subLocation}</h2>
-        </div>
+    this.actionPanel.innerHTML = this.renderPanelFrame({
+      key: "action",
+      eyebrow: "FIELD ACTIONS",
+      title: currentLocation.subLocation,
+      controls: `
         <div class="dock-summary">
           <span class="pill">${currentLocation.mainLocation}</span>
           ${equippedPills}
         </div>
-      </div>
-      <div class="dock-grid">
-        ${restingVisible ? `<button class="dock-card accent" data-rest><strong>숙박</strong><span>20 코인으로 HP/MP 회복</span></button>` : ""}
-        ${equipmentButtons}
-        ${skillButtons}
-        ${!hasContextActions ? `<div class="dock-card static"><strong>탐험 구간</strong><span>출구 진입 후 Enter 로 씬 전환, NPC 근처에서 Space 로 대화</span></div>` : ""}
-        ${battle ? `<div class="dock-card static danger"><strong>전투 진행 중</strong><span>오른쪽 전투 오버레이에서 행동을 선택하세요.</span></div>` : ""}
-        ${battleReport ? `
-          <div class="dock-card static ${battleReport.outcome === "enemy_win" ? "danger" : "accent"} report-card">
-            <strong>${battleReport.title}</strong>
-            <span>${battleReport.summary}</span>
-            <span>최근 전투 로그 ${battleReport.lines.length}개가 오른쪽 패널에 반영되었습니다.</span>
-          </div>
-        ` : ""}
-      </div>
-    `;
+      `,
+      body: `
+        <div class="dock-grid">
+          ${restingVisible ? `<button class="dock-card accent" data-rest><strong>숙박</strong><span>20 코인으로 HP/MP 회복</span></button>` : ""}
+          ${equipmentButtons}
+          ${skillButtons}
+          ${!hasContextActions ? `<div class="dock-card static"><strong>탐험 구간</strong><span>출구 진입 후 Enter 로 씬 전환, NPC 근처에서 Space 로 대화</span></div>` : ""}
+          ${battle ? `<div class="dock-card static danger"><strong>전투 진행 중</strong><span>오른쪽 전투 오버레이에서 행동을 선택하세요.</span></div>` : ""}
+          ${battleReport ? `
+            <div class="dock-card static ${battleReport.outcome === "enemy_win" ? "danger" : "accent"} report-card">
+              <strong>${battleReport.title}</strong>
+              <span>${battleReport.summary}</span>
+              <span>최근 전투 로그 ${battleReport.lines.length}개가 오른쪽 패널에 반영되었습니다.</span>
+            </div>
+          ` : ""}
+        </div>
+      `,
+    });
 
     this.actionPanel.querySelectorAll<HTMLButtonElement>("[data-equipment]").forEach((button) => {
       const equipmentId = button.dataset.equipment!;
@@ -654,6 +771,7 @@ export class DomUi {
     if (restButton) {
       restButton.onclick = () => this.callbacks.onRest();
     }
+    this.bindPanelToggle("action");
   }
 
   private renderDialogue(state: AppState): void {
@@ -665,19 +783,21 @@ export class DomUi {
 
     const currentLine = state.dialogue.lines[state.dialogue.index] ?? "";
     this.dialoguePanel.classList.add("visible");
-    this.dialoguePanel.innerHTML = `
-      <div class="eyebrow">DIALOGUE</div>
-      <div class="panel-header">
-        <h2>${state.dialogue.title}</h2>
-        <span>${state.dialogue.index + 1} / ${state.dialogue.lines.length}</span>
-      </div>
-      <p class="dialogue-line">${currentLine}</p>
-      <div class="dialogue-footer">
-        <p class="panel-note">Space 또는 Enter 로 계속 진행할 수 있습니다.</p>
-        <button class="primary" data-dialogue-next>${state.dialogue.index >= state.dialogue.lines.length - 1 ? "닫기" : "다음"}</button>
-      </div>
-    `;
+    this.dialoguePanel.innerHTML = this.renderPanelFrame({
+      key: "dialogue",
+      eyebrow: "DIALOGUE",
+      title: state.dialogue.title,
+      controls: `<span class="pill">${state.dialogue.index + 1} / ${state.dialogue.lines.length}</span>`,
+      body: `
+        <p class="dialogue-line">${currentLine}</p>
+        <div class="dialogue-footer">
+          <p class="panel-note">Space 또는 Enter 로 계속 진행할 수 있습니다.</p>
+          <button class="primary" data-dialogue-next>${state.dialogue.index >= state.dialogue.lines.length - 1 ? "닫기" : "다음"}</button>
+        </div>
+      `,
+    });
     (this.dialoguePanel.querySelector("[data-dialogue-next]") as HTMLButtonElement).onclick = () => this.callbacks.onDialogueNext();
+    this.bindPanelToggle("dialogue");
   }
 
   private renderBattle(battle: BattleState | null, skills: SkillDefinition[], tactics: TacticDefinition[]): void {
@@ -694,49 +814,50 @@ export class DomUi {
     ].filter((entry): entry is string => Boolean(entry));
 
     this.battlePanel.classList.add("visible");
-    this.battlePanel.innerHTML = `
-      <div class="eyebrow">BATTLE</div>
-      <div class="panel-header">
-        <h2>${battle.enemy.name}</h2>
-        <span>턴 ${battle.turnNumber}</span>
-      </div>
-      <div class="battle-stats">
-        <div><span>적 HP</span><strong>${Math.round(battle.enemy.currentHp)} / ${battle.enemy.maxHp}</strong></div>
-        <div><span>내 HP</span><strong>${Math.round(battle.player.currentHp)} / ${battle.player.maxHp}</strong></div>
-        <div><span>내 MP</span><strong>${Math.round(battle.player.currentMp)} / ${battle.player.maxMp}</strong></div>
-        <div><span>전황</span><strong>${battle.isBoss ? "보스전" : "일반전"}</strong></div>
-      </div>
-      <div class="battle-status-strip">
-        ${statuses.map((status) => `<span class="pill">${status}</span>`).join("") || `<span class="pill muted">지속 효과 없음</span>`}
-      </div>
-      <div class="battle-actions">
-        <button data-battle-basic="attack"><strong>공격</strong><span>1</span></button>
-        <button data-battle-basic="normal"><strong>일반</strong><span>2</span></button>
-        <button data-battle-basic="defend"><strong>방어</strong><span>3</span></button>
-      </div>
-      <div class="action-stack">
-        <h3>특수 기술</h3>
-        ${skills.map((skill) => `
-          <button data-battle-skill="${skill.id}" ${battle.player.currentMp < skill.manaCost ? "disabled" : ""}>
-            <strong>${skill.name}</strong>
-            <span>MP ${skill.manaCost}</span>
-          </button>
-        `).join("") || `<p class="panel-note">습득한 기술이 없습니다.</p>`}
-      </div>
-      <div class="action-stack">
-        <h3>전술</h3>
-        ${tactics.map((tactic) => `
-          <button data-battle-tactic="${tactic.id}">
-            <strong>${tactic.name}</strong>
-            <span>${tactic.description}</span>
-          </button>
-        `).join("") || `<p class="panel-note">습득한 전술이 없습니다.</p>`}
-      </div>
-      <div class="action-stack battle-feed">
-        <h3>최근 전황</h3>
-        ${battle.log.slice(-6).map((entry) => `<div class="battle-feed-item">${entry}</div>`).join("")}
-      </div>
-    `;
+    this.battlePanel.innerHTML = this.renderPanelFrame({
+      key: "battle",
+      eyebrow: "BATTLE",
+      title: battle.enemy.name,
+      controls: `<span class="pill">턴 ${battle.turnNumber}</span>`,
+      body: `
+        <div class="battle-stats">
+          <div><span>적 HP</span><strong>${Math.round(battle.enemy.currentHp)} / ${battle.enemy.maxHp}</strong></div>
+          <div><span>내 HP</span><strong>${Math.round(battle.player.currentHp)} / ${battle.player.maxHp}</strong></div>
+          <div><span>내 MP</span><strong>${Math.round(battle.player.currentMp)} / ${battle.player.maxMp}</strong></div>
+          <div><span>전황</span><strong>${battle.isBoss ? "보스전" : "일반전"}</strong></div>
+        </div>
+        <div class="battle-status-strip">
+          ${statuses.map((status) => `<span class="pill">${status}</span>`).join("") || `<span class="pill muted">지속 효과 없음</span>`}
+        </div>
+        <div class="battle-actions">
+          <button data-battle-basic="attack"><strong>공격</strong><span>1</span></button>
+          <button data-battle-basic="normal"><strong>일반</strong><span>2</span></button>
+          <button data-battle-basic="defend"><strong>방어</strong><span>3</span></button>
+        </div>
+        <div class="action-stack">
+          <h3>특수 기술</h3>
+          ${skills.map((skill) => `
+            <button data-battle-skill="${skill.id}" ${battle.player.currentMp < skill.manaCost ? "disabled" : ""}>
+              <strong>${skill.name}</strong>
+              <span>MP ${skill.manaCost}</span>
+            </button>
+          `).join("") || `<p class="panel-note">습득한 기술이 없습니다.</p>`}
+        </div>
+        <div class="action-stack">
+          <h3>전술</h3>
+          ${tactics.map((tactic) => `
+            <button data-battle-tactic="${tactic.id}">
+              <strong>${tactic.name}</strong>
+              <span>${tactic.description}</span>
+            </button>
+          `).join("") || `<p class="panel-note">습득한 전술이 없습니다.</p>`}
+        </div>
+        <div class="action-stack battle-feed">
+          <h3>최근 전황</h3>
+          ${battle.log.slice(-6).map((entry) => `<div class="battle-feed-item">${entry}</div>`).join("")}
+        </div>
+      `,
+    });
 
     this.battlePanel.querySelectorAll<HTMLButtonElement>("[data-battle-basic]").forEach((button) => {
       button.onclick = () => this.callbacks.onBattleAction({ kind: button.dataset.battleBasic as "attack" | "normal" | "defend" });
@@ -747,6 +868,7 @@ export class DomUi {
     this.battlePanel.querySelectorAll<HTMLButtonElement>("[data-battle-tactic]").forEach((button) => {
       button.onclick = () => this.callbacks.onBattleAction({ kind: "tactic", tacticId: button.dataset.battleTactic! });
     });
+    this.bindPanelToggle("battle");
   }
 
   private renderChat(state: AppState): void {
@@ -756,28 +878,27 @@ export class DomUi {
       ? "같은 씬의 유저에게 말하기"
       : "연결 복구 후 채팅 가능";
 
-    this.chatPanel.innerHTML = `
-      <div class="panel-header">
-        <div>
-          <div class="eyebrow">SOCIAL</div>
-          <h2>지역 채팅</h2>
+    this.chatPanel.innerHTML = this.renderPanelFrame({
+      key: "chat",
+      eyebrow: "SOCIAL",
+      title: "지역 채팅",
+      controls: `<span class="status-pill ${state.connectionStatus}">${nearbyPlayers.length} nearby</span>`,
+      body: `
+        <div class="presence-strip">
+          ${nearbyPlayers.map((presence) => `<span class="pill">${presence.username}</span>`).join("") || `<span class="pill muted">같은 씬의 다른 유저 없음</span>`}
         </div>
-        <span class="status-pill ${state.connectionStatus}">${nearbyPlayers.length} nearby</span>
-      </div>
-      <div class="presence-strip">
-        ${nearbyPlayers.map((presence) => `<span class="pill">${presence.username}</span>`).join("") || `<span class="pill muted">같은 씬의 다른 유저 없음</span>`}
-      </div>
-      <div class="chat-list">
-        ${state.chatMessages
-          .slice(-8)
-          .map((message) => `<div class="chat-item"><strong>${message.username}</strong><span>${message.text}</span></div>`)
-          .join("") || `<p class="panel-note">${state.connectionStatus === "online" ? "같은 씬의 유저에게 말을 걸 수 있습니다." : "실시간 연결이 복구되면 채팅이 다시 활성화됩니다."}</p>`}
-      </div>
-      <form class="chat-form">
-        <input name="text" placeholder="${chatPlaceholder}" ${canChat ? "" : "disabled"} />
-        <button type="submit" class="primary" ${canChat ? "" : "disabled"}>전송</button>
-      </form>
-    `;
+        <div class="chat-list">
+          ${state.chatMessages
+            .slice(-8)
+            .map((message) => `<div class="chat-item"><strong>${message.username}</strong><span>${message.text}</span></div>`)
+            .join("") || `<p class="panel-note">${state.connectionStatus === "online" ? "같은 씬의 유저에게 말을 걸 수 있습니다." : "실시간 연결이 복구되면 채팅이 다시 활성화됩니다."}</p>`}
+        </div>
+        <form class="chat-form">
+          <input name="text" placeholder="${chatPlaceholder}" ${canChat ? "" : "disabled"} />
+          <button type="submit" class="primary" ${canChat ? "" : "disabled"}>전송</button>
+        </form>
+      `,
+    });
     const form = this.chatPanel.querySelector(".chat-form") as HTMLFormElement;
     form.onsubmit = (event) => {
       event.preventDefault();
@@ -788,20 +909,22 @@ export class DomUi {
         if (input) input.value = "";
       }
     };
+    this.bindPanelToggle("chat");
   }
 
   private renderLogs(logs: string[]): void {
-    this.logPanel.innerHTML = `
-      <div class="panel-header">
-        <div>
-          <div class="eyebrow">EVENT FEED</div>
-          <h2>최근 이벤트</h2>
+    this.logPanel.innerHTML = this.renderPanelFrame({
+      key: "log",
+      eyebrow: "EVENT FEED",
+      title: "최근 이벤트",
+      controls: `<span class="pill">${Math.min(logs.length, 6)} entries</span>`,
+      body: `
+        <div class="log-list">
+          ${logs.slice(0, 6).map((entry) => `<div class="log-item">${entry}</div>`).join("") || `<p class="panel-note">저장, 이동, 전투 결과가 여기에 쌓입니다.</p>`}
         </div>
-      </div>
-      <div class="log-list">
-        ${logs.slice(0, 6).map((entry) => `<div class="log-item">${entry}</div>`).join("") || `<p class="panel-note">저장, 이동, 전투 결과가 여기에 쌓입니다.</p>`}
-      </div>
-    `;
+      `,
+    });
+    this.bindPanelToggle("log");
   }
 
   private renderPlayerMeters(player: PlayerSave, nearbyCount: number): string {

--- a/apps/web/src/ui/layout.ts
+++ b/apps/web/src/ui/layout.ts
@@ -1,0 +1,97 @@
+export const FLOATING_LAYOUT_STORAGE_KEY = "rpg-rebuild-floating-layout-v1";
+export const FLOATING_LAYOUT_BREAKPOINT = 920;
+
+export type FloatingPanelKey = "hud" | "log" | "chat" | "action" | "dialogue" | "battle";
+
+export type FloatingPanelLayout = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  z: number;
+};
+
+export type FloatingPanelConstraint = {
+  minWidth: number;
+  minHeight: number;
+};
+
+const PANEL_KEYS: FloatingPanelKey[] = ["hud", "log", "chat", "action", "dialogue", "battle"];
+
+export const FLOATING_PANEL_CONSTRAINTS: Record<FloatingPanelKey, FloatingPanelConstraint> = {
+  hud: { minWidth: 480, minHeight: 160 },
+  log: { minWidth: 260, minHeight: 180 },
+  chat: { minWidth: 280, minHeight: 220 },
+  action: { minWidth: 360, minHeight: 180 },
+  dialogue: { minWidth: 360, minHeight: 180 },
+  battle: { minWidth: 380, minHeight: 260 },
+};
+
+export function isFloatingLayoutEnabled(viewportWidth: number): boolean {
+  return viewportWidth > FLOATING_LAYOUT_BREAKPOINT;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+export function sanitizeStoredLayouts(value: unknown): Partial<Record<FloatingPanelKey, FloatingPanelLayout>> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+
+  const record = value as Record<string, unknown>;
+  const output: Partial<Record<FloatingPanelKey, FloatingPanelLayout>> = {};
+
+  PANEL_KEYS.forEach((key) => {
+    const candidate = record[key];
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+      return;
+    }
+
+    const layout = candidate as Record<string, unknown>;
+    if (
+      !isFiniteNumber(layout.x)
+      || !isFiniteNumber(layout.y)
+      || !isFiniteNumber(layout.width)
+      || !isFiniteNumber(layout.height)
+      || !isFiniteNumber(layout.z)
+    ) {
+      return;
+    }
+
+    output[key] = {
+      x: layout.x,
+      y: layout.y,
+      width: layout.width,
+      height: layout.height,
+      z: Math.max(1, Math.round(layout.z)),
+    };
+  });
+
+  return output;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function clampFloatingPanelLayout(
+  key: FloatingPanelKey,
+  layout: FloatingPanelLayout,
+  container: { width: number; height: number },
+): FloatingPanelLayout {
+  const constraint = FLOATING_PANEL_CONSTRAINTS[key];
+  const width = clamp(Math.round(layout.width), constraint.minWidth, Math.max(constraint.minWidth, Math.round(container.width)));
+  const height = clamp(Math.round(layout.height), constraint.minHeight, Math.max(constraint.minHeight, Math.round(container.height)));
+  const maxX = Math.max(0, Math.round(container.width) - width);
+  const maxY = Math.max(0, Math.round(container.height) - height);
+
+  return {
+    x: clamp(Math.round(layout.x), 0, maxX),
+    y: clamp(Math.round(layout.y), 0, maxY),
+    width,
+    height,
+    z: Math.max(1, Math.round(layout.z)),
+  };
+}

--- a/apps/web/src/ui/layout.ts
+++ b/apps/web/src/ui/layout.ts
@@ -72,6 +72,14 @@ export function sanitizeStoredLayouts(value: unknown): Partial<Record<FloatingPa
   return output;
 }
 
+export function cloneFloatingLayouts(
+  layouts: Partial<Record<FloatingPanelKey, FloatingPanelLayout>>,
+): Partial<Record<FloatingPanelKey, FloatingPanelLayout>> {
+  return Object.fromEntries(
+    Object.entries(layouts).map(([key, layout]) => [key, layout ? { ...layout } : layout]),
+  ) as Partial<Record<FloatingPanelKey, FloatingPanelLayout>>;
+}
+
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
 }

--- a/apps/web/src/ui/layout.ts
+++ b/apps/web/src/ui/layout.ts
@@ -3,12 +3,19 @@ export const FLOATING_LAYOUT_BREAKPOINT = 920;
 
 export type FloatingPanelKey = "hud" | "log" | "chat" | "action" | "dialogue" | "battle";
 
+export type FloatingPanelCollapsedState = Partial<Record<FloatingPanelKey, boolean>>;
+
 export type FloatingPanelLayout = {
   x: number;
   y: number;
   width: number;
   height: number;
   z: number;
+};
+
+export type FloatingPanelPreferences = {
+  layouts: Partial<Record<FloatingPanelKey, FloatingPanelLayout>>;
+  collapsed: FloatingPanelCollapsedState;
 };
 
 export type FloatingPanelConstraint = {
@@ -33,6 +40,21 @@ export function isFloatingLayoutEnabled(viewportWidth: number): boolean {
 
 function isFiniteNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
+}
+
+function sanitizeCollapsedPanels(value: unknown): FloatingPanelCollapsedState {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+
+  const record = value as Record<string, unknown>;
+  const output: FloatingPanelCollapsedState = {};
+  PANEL_KEYS.forEach((key) => {
+    if (typeof record[key] === "boolean") {
+      output[key] = record[key];
+    }
+  });
+  return output;
 }
 
 export function sanitizeStoredLayouts(value: unknown): Partial<Record<FloatingPanelKey, FloatingPanelLayout>> {
@@ -72,12 +94,33 @@ export function sanitizeStoredLayouts(value: unknown): Partial<Record<FloatingPa
   return output;
 }
 
+export function sanitizeStoredPanelPreferences(value: unknown): FloatingPanelPreferences {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const record = value as Record<string, unknown>;
+    if ("layouts" in record || "collapsed" in record) {
+      return {
+        layouts: sanitizeStoredLayouts(record.layouts),
+        collapsed: sanitizeCollapsedPanels(record.collapsed),
+      };
+    }
+  }
+
+  return {
+    layouts: sanitizeStoredLayouts(value),
+    collapsed: {},
+  };
+}
+
 export function cloneFloatingLayouts(
   layouts: Partial<Record<FloatingPanelKey, FloatingPanelLayout>>,
 ): Partial<Record<FloatingPanelKey, FloatingPanelLayout>> {
   return Object.fromEntries(
     Object.entries(layouts).map(([key, layout]) => [key, layout ? { ...layout } : layout]),
   ) as Partial<Record<FloatingPanelKey, FloatingPanelLayout>>;
+}
+
+export function cloneCollapsedPanels(collapsed: FloatingPanelCollapsedState): FloatingPanelCollapsedState {
+  return { ...collapsed };
 }
 
 function clamp(value: number, min: number, max: number): number {

--- a/apps/web/test/layout.test.ts
+++ b/apps/web/test/layout.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   clampFloatingPanelLayout,
+  cloneFloatingLayouts,
   isFloatingLayoutEnabled,
   sanitizeStoredLayouts,
 } from "../src/ui/layout";
@@ -56,5 +57,21 @@ describe("floating panel layout helpers", () => {
       height: 600,
       z: 1,
     });
+  });
+
+  it("clones layout records without sharing object references", () => {
+    const original = {
+      hud: {
+        x: 18,
+        y: 18,
+        width: 800,
+        height: 220,
+        z: 2,
+      },
+    };
+
+    const cloned = cloneFloatingLayouts(original);
+    expect(cloned).toEqual(original);
+    expect(cloned.hud).not.toBe(original.hud);
   });
 });

--- a/apps/web/test/layout.test.ts
+++ b/apps/web/test/layout.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  clampFloatingPanelLayout,
+  isFloatingLayoutEnabled,
+  sanitizeStoredLayouts,
+} from "../src/ui/layout";
+
+describe("floating panel layout helpers", () => {
+  it("enables floating layouts only above the desktop breakpoint", () => {
+    expect(isFloatingLayoutEnabled(921)).toBe(true);
+    expect(isFloatingLayoutEnabled(920)).toBe(false);
+  });
+
+  it("sanitizes malformed stored layout payloads", () => {
+    const layouts = sanitizeStoredLayouts({
+      chat: {
+        x: 32,
+        y: 48,
+        width: 320,
+        height: 280,
+        z: 9,
+      },
+      broken: {
+        x: "nope",
+      },
+      battle: null,
+    });
+
+    expect(layouts.chat).toEqual({
+      x: 32,
+      y: 48,
+      width: 320,
+      height: 280,
+      z: 9,
+    });
+    expect("broken" in layouts).toBe(false);
+    expect(layouts.battle).toBeUndefined();
+  });
+
+  it("clamps panel bounds to the visible container and minimum sizes", () => {
+    const clamped = clampFloatingPanelLayout("chat", {
+      x: 900,
+      y: -24,
+      width: 120,
+      height: 1000,
+      z: 0,
+    }, {
+      width: 800,
+      height: 600,
+    });
+
+    expect(clamped).toEqual({
+      x: 520,
+      y: 0,
+      width: 280,
+      height: 600,
+      z: 1,
+    });
+  });
+});

--- a/apps/web/test/layout.test.ts
+++ b/apps/web/test/layout.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   clampFloatingPanelLayout,
+  cloneCollapsedPanels,
   cloneFloatingLayouts,
   isFloatingLayoutEnabled,
+  sanitizeStoredPanelPreferences,
   sanitizeStoredLayouts,
 } from "../src/ui/layout";
 
@@ -36,6 +38,31 @@ describe("floating panel layout helpers", () => {
     });
     expect("broken" in layouts).toBe(false);
     expect(layouts.battle).toBeUndefined();
+  });
+
+  it("reads saved collapsed panel state from the newer preference payload", () => {
+    const preferences = sanitizeStoredPanelPreferences({
+      layouts: {
+        chat: {
+          x: 24,
+          y: 36,
+          width: 320,
+          height: 260,
+          z: 4,
+        },
+      },
+      collapsed: {
+        chat: true,
+        battle: false,
+        nope: "bad",
+      },
+    });
+
+    expect(preferences.layouts.chat?.width).toBe(320);
+    expect(preferences.collapsed).toEqual({
+      chat: true,
+      battle: false,
+    });
   });
 
   it("clamps panel bounds to the visible container and minimum sizes", () => {
@@ -73,5 +100,16 @@ describe("floating panel layout helpers", () => {
     const cloned = cloneFloatingLayouts(original);
     expect(cloned).toEqual(original);
     expect(cloned.hud).not.toBe(original.hud);
+  });
+
+  it("clones collapsed panel state without sharing object references", () => {
+    const original = {
+      chat: true,
+      log: false,
+    };
+
+    const cloned = cloneCollapsedPanels(original);
+    expect(cloned).toEqual(original);
+    expect(cloned).not.toBe(original);
   });
 });


### PR DESCRIPTION
## Summary
- HUD, 로그, 채팅, 액션, 대화, 전투 패널에 데스크톱 전용 드래그 이동과 리사이즈를 적용했습니다
- 패널 위치와 크기를 localStorage에 저장하고, 새로고침 후 같은 배치를 복원하도록 했습니다
- 좁은 화면에서는 기존 스택 레이아웃으로 안전하게 비활성화하고, HUD에서 배치 초기화도 가능하게 했습니다

## Testing
- corepack pnpm --filter @rpg/web typecheck
- corepack pnpm --filter @rpg/web test
- corepack pnpm --filter @rpg/web lint
- corepack pnpm --filter @rpg/web build

Closes #26