### PR TITLE
fix: 입력 포커스 중 게임 단축키 충돌 방지

### DIFF
--- a/apps/web/src/AppController.ts
+++ b/apps/web/src/AppController.ts
@@ -25,6 +25,7 @@ import { ApiClient } from "./net/api";
 import { PresenceClient } from "./net/socket";
 import { GameBridge } from "./game/GameBridge";
 import { AppStore } from "./state/store";
+import { shouldBlockGameplayInput } from "./input";
 import {
   advanceDialogueProgress,
   createLocationStoryDialogue,
@@ -43,7 +44,7 @@ export class AppController {
   private readonly presence: PresenceClient;
   private lastSavedAt = 0;
   private readonly handleGlobalKeydown = (event: KeyboardEvent) => {
-    if (this.isTextEntryTarget(event.target)) {
+    if (this.isGameplayInputBlocked(event.target)) {
       return;
     }
 
@@ -105,6 +106,7 @@ export class AppController {
         const state = this.store.getState();
         return Boolean(state.player && !state.battle && !state.dialogue);
       },
+      isGameplayInputBlocked: () => this.isGameplayInputBlocked(this.getActiveElement()),
       getOverlayMode: () => deriveOverlayMode(this.store.getState()),
       hasPendingLocationStory: () => {
         const state = this.store.getState();
@@ -676,11 +678,16 @@ export class AppController {
     }));
   }
 
-  private isTextEntryTarget(target: EventTarget | null): boolean {
-    if (!(target instanceof HTMLElement)) {
-      return false;
+  private isGameplayInputBlocked(target: EventTarget | null): boolean {
+    return shouldBlockGameplayInput(target, this.getActiveElement());
+  }
+
+  private getActiveElement(): Element | null {
+    if (typeof document === "undefined") {
+      return null;
     }
-    return target.closest("input, textarea, [contenteditable='true']") !== null;
+
+    return document.activeElement;
   }
 
   private applyEquipmentSelection(player: PlayerSave, equippedEquipmentIds: string[]): PlayerSave {

--- a/apps/web/src/game/GameBridge.ts
+++ b/apps/web/src/game/GameBridge.ts
@@ -8,6 +8,7 @@ import { OverworldScene } from "./OverworldScene";
 
 type BridgeCallbacks = {
   canMove: () => boolean;
+  isGameplayInputBlocked: () => boolean;
   getOverlayMode: () => OverlayMode;
   hasPendingLocationStory: () => boolean;
   onPositionChange: (x: number, y: number, facing: Facing) => void;

--- a/apps/web/src/game/OverworldScene.ts
+++ b/apps/web/src/game/OverworldScene.ts
@@ -12,6 +12,7 @@ import type { FieldPrompt, OverlayMode } from "../gameplay";
 
 type SceneCallbacks = {
   canMove: () => boolean;
+  isGameplayInputBlocked: () => boolean;
   getOverlayMode: () => OverlayMode;
   hasPendingLocationStory: () => boolean;
   onPositionChange: (x: number, y: number, facing: Facing) => void;
@@ -73,6 +74,7 @@ export class OverworldScene extends Phaser.Scene {
   private lastPresenceSentAt = 0;
   private lastBroadcastKey = "";
   private lastPromptKey = "";
+  private gameplayCaptureDisabled = false;
 
   constructor() {
     super("overworld");
@@ -87,6 +89,10 @@ export class OverworldScene extends Phaser.Scene {
     this.keyEnter = this.input.keyboard!.addKey("ENTER");
     this.keySpace = this.input.keyboard!.addKey("SPACE");
     this.keyBattle = this.input.keyboard!.addKey("B");
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
+      this.input.keyboard?.enableGlobalCapture();
+      this.gameplayCaptureDisabled = false;
+    });
 
     if (this.world && this.playerState) {
       this.buildLocation();
@@ -159,7 +165,9 @@ export class OverworldScene extends Phaser.Scene {
     }
 
     const overlayMode = this.callbacks.getOverlayMode();
-    const canExplore = overlayMode === "explore" && this.callbacks.canMove();
+    const gameplayInputBlocked = this.callbacks.isGameplayInputBlocked();
+    this.syncGameplayCapture(gameplayInputBlocked);
+    const canExplore = overlayMode === "explore" && this.callbacks.canMove() && !gameplayInputBlocked;
     const speed = canExplore ? 160 : 0;
     let velocityX = 0;
     let velocityY = 0;
@@ -242,6 +250,22 @@ export class OverworldScene extends Phaser.Scene {
     if (activeEncounter && Phaser.Input.Keyboard.JustDown(this.keyBattle)) {
       this.callbacks.onEncounter(activeEncounter.data);
     }
+  }
+
+  private syncGameplayCapture(gameplayInputBlocked: boolean): void {
+    const keyboard = this.input.keyboard;
+    if (!keyboard || gameplayInputBlocked === this.gameplayCaptureDisabled) {
+      return;
+    }
+
+    if (gameplayInputBlocked) {
+      keyboard.disableGlobalCapture();
+      keyboard.resetKeys();
+    } else {
+      keyboard.enableGlobalCapture();
+    }
+
+    this.gameplayCaptureDisabled = gameplayInputBlocked;
   }
 
   private buildLocation(): void {

--- a/apps/web/src/input.ts
+++ b/apps/web/src/input.ts
@@ -1,0 +1,55 @@
+const TEXT_INPUT_TAGS = new Set(["input", "textarea", "select", "option"]);
+
+const GAMEPLAY_SHORTCUT_KEYS = new Set([
+  "w",
+  "a",
+  "s",
+  "d",
+  "arrowup",
+  "arrowdown",
+  "arrowleft",
+  "arrowright",
+  " ",
+  "space",
+  "spacebar",
+  "enter",
+  "b",
+  "1",
+  "2",
+  "3",
+]);
+
+type ClosestCapableTarget = {
+  tagName?: string | null;
+  isContentEditable?: boolean;
+  closest?: (selector: string) => unknown;
+};
+
+function isClosestCapableTarget(target: unknown): target is ClosestCapableTarget {
+  return typeof target === "object" && target !== null;
+}
+
+export function isTextInputTag(tagName: string | null | undefined, isContentEditable: boolean): boolean {
+  if (!tagName) {
+    return isContentEditable;
+  }
+
+  return TEXT_INPUT_TAGS.has(tagName.toLowerCase()) || isContentEditable;
+}
+
+export function isTextInputTarget(target: EventTarget | Element | null): boolean {
+  if (!isClosestCapableTarget(target)) {
+    return false;
+  }
+
+  return isTextInputTag(target.tagName, Boolean(target.isContentEditable))
+    || (typeof target.closest === "function" && target.closest("input, textarea, select, option, [contenteditable='true']") !== null);
+}
+
+export function isGameplayShortcutKey(key: string): boolean {
+  return GAMEPLAY_SHORTCUT_KEYS.has(key.trim().toLowerCase());
+}
+
+export function shouldBlockGameplayInput(target: EventTarget | null, activeElement: Element | null): boolean {
+  return isTextInputTarget(target) || isTextInputTarget(activeElement);
+}

--- a/apps/web/test/input.test.ts
+++ b/apps/web/test/input.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { isGameplayShortcutKey, isTextInputTag, shouldBlockGameplayInput } from "../src/input";
+
+function createClosestTarget(options: {
+  tagName?: string;
+  isContentEditable?: boolean;
+  closestResult?: unknown;
+} = {}) {
+  return {
+    tagName: options.tagName ?? "div",
+    isContentEditable: options.isContentEditable ?? false,
+    closest: () => options.closestResult ?? null,
+  };
+}
+
+describe("input helpers", () => {
+  it("recognizes common gameplay shortcut keys", () => {
+    expect(isGameplayShortcutKey("W")).toBe(true);
+    expect(isGameplayShortcutKey("ArrowLeft")).toBe(true);
+    expect(isGameplayShortcutKey("Space")).toBe(true);
+    expect(isGameplayShortcutKey("Enter")).toBe(true);
+    expect(isGameplayShortcutKey("B")).toBe(true);
+    expect(isGameplayShortcutKey("1")).toBe(true);
+    expect(isGameplayShortcutKey("x")).toBe(false);
+  });
+
+  it("recognizes text entry tags and contenteditable nodes", () => {
+    expect(isTextInputTag("input", false)).toBe(true);
+    expect(isTextInputTag("TEXTAREA", false)).toBe(true);
+    expect(isTextInputTag("div", true)).toBe(true);
+    expect(isTextInputTag("button", false)).toBe(false);
+  });
+
+  it("blocks gameplay input when the key target is a text entry control", () => {
+    const inputTarget = createClosestTarget({ tagName: "input" }) as unknown as EventTarget;
+
+    expect(shouldBlockGameplayInput(inputTarget, null)).toBe(true);
+  });
+
+  it("blocks gameplay input when another text field keeps active focus", () => {
+    const nonInputTarget = createClosestTarget({ tagName: "button" }) as unknown as EventTarget;
+    const activeInput = createClosestTarget({ tagName: "textarea" }) as unknown as Element;
+
+    expect(shouldBlockGameplayInput(nonInputTarget, activeInput)).toBe(true);
+  });
+});


### PR DESCRIPTION
## 요약\n- 텍스트 입력 포커스가 있을 때 게임 단축키 입력을 공통 유틸로 차단합니다.\n- OverworldScene 에서 입력 포커스 중 Phaser global capture 를 내려서 실제로 비밀번호와 채팅 입력이 가능하도록 보강했습니다.\n- 입력 가드 회귀를 막는 테스트를 추가했습니다.\n\n## 변경 내용\n- AppController 와 OverworldScene 이 같은 입력 차단 규칙을 사용하도록 정리\n- 입력 포커스 중 WASD, 방향키, Space, Enter, B, 1/2/3 충돌 방지\n- apps/web/src/input.ts 추가\n- apps/web/test/input.test.ts 추가\n\n## 검증\n- corepack pnpm --filter @rpg/web typecheck\n- corepack pnpm --filter @rpg/web test\n- corepack pnpm --filter @rpg/web lint\n- corepack pnpm --filter @rpg/web build\n\nCloses #25