### PR TITLE
perf: 웹 번들 분할과 Phaser 런타임 지연 로딩 최적화

### DIFF
--- a/apps/web/src/AppController.ts
+++ b/apps/web/src/AppController.ts
@@ -21,9 +21,9 @@ import {
 } from "@rpg/game-core";
 import { validateAuthCredentials } from "./auth";
 import { createBattleReport, deriveOverlayMode, didSceneChange } from "./gameplay";
+import type { FieldPrompt } from "./gameplay";
 import { ApiClient } from "./net/api";
 import { PresenceClient } from "./net/socket";
-import { GameBridge } from "./game/GameBridge";
 import { AppStore } from "./state/store";
 import { shouldBlockGameplayInput } from "./input";
 import {
@@ -36,11 +36,32 @@ import { DomUi } from "./ui/dom";
 
 const TOKEN_KEY = "rpg-rebuild-token";
 
+type GameRuntime = {
+  sync: (world: WorldContent | null, player: PlayerSave | null, nearbyPlayers: PresenceState[]) => void;
+  destroy: () => void;
+};
+
+type GameBridgeCallbacks = {
+  canMove: () => boolean;
+  isGameplayInputBlocked: () => boolean;
+  getOverlayMode: () => ReturnType<typeof deriveOverlayMode>;
+  hasPendingLocationStory: () => boolean;
+  onPositionChange: (x: number, y: number, facing: Facing) => void;
+  onSceneChange: (locationKey: string) => void;
+  onOpenLocationStory: () => void;
+  onInteractNpc: (npc: DialogueNpc) => void;
+  onEncounter: (zone: EncounterZone) => void;
+  onFieldPromptChange: (prompt: FieldPrompt) => void;
+};
+
 export class AppController {
   private readonly store = new AppStore();
   private readonly api = new ApiClient(import.meta.env.VITE_API_BASE_URL ?? "http://localhost:4000");
   private readonly ui: DomUi;
-  private readonly game: GameBridge;
+  private game: GameRuntime | null = null;
+  private gamePromise: Promise<GameRuntime> | null = null;
+  private gameRetryTimer: number | null = null;
+  private hasRetriedGameLoad = false;
   private readonly presence: PresenceClient;
   private lastSavedAt = 0;
   private readonly handleGlobalKeydown = (event: KeyboardEvent) => {
@@ -101,33 +122,6 @@ export class AppController {
       onSendChat: (text) => this.presence.sendChat(text),
     });
 
-    this.game = new GameBridge(this.ui.getGameContainer(), {
-      canMove: () => {
-        const state = this.store.getState();
-        return Boolean(state.player && !state.battle && !state.dialogue);
-      },
-      isGameplayInputBlocked: () => this.isGameplayInputBlocked(this.getActiveElement()),
-      getOverlayMode: () => deriveOverlayMode(this.store.getState()),
-      hasPendingLocationStory: () => {
-        const state = this.store.getState();
-        if (!state.player || !state.world) {
-          return false;
-        }
-        const location = state.world.locations[state.player.locationKey] ?? null;
-        return hasUnreadLocationStory(state.player, location);
-      },
-      onPositionChange: (x, y, facing) => this.updatePosition(x, y, facing),
-      onSceneChange: (locationKey) => {
-        void this.changeLocation(locationKey);
-      },
-      onOpenLocationStory: () => this.openCurrentLocationStory(),
-      onInteractNpc: (npc) => this.openNpcDialogue(npc),
-      onEncounter: (zone) => {
-        void this.startEncounter(zone);
-      },
-      onFieldPromptChange: (prompt) => this.store.setState({ fieldPrompt: prompt }),
-    });
-
     this.presence = new PresenceClient(import.meta.env.VITE_API_BASE_URL ?? "http://localhost:4000", {
       onSnapshot: (snapshot) => this.setPresence(snapshot),
       onPresenceJoined: (presence) => this.handlePresenceJoined(presence),
@@ -170,7 +164,7 @@ export class AppController {
         : [];
 
       this.ui.render(state, currentLocation, equipmentForLocation, skillsForLocation, equipped, learnedSkills, learnedTactics);
-      this.game.sync(state.world, state.player, state.presence);
+      this.game?.sync(state.world, state.player, state.presence);
     });
 
     window.addEventListener("keydown", this.handleGlobalKeydown);
@@ -181,6 +175,7 @@ export class AppController {
     try {
       const world = await this.api.bootstrap();
       this.store.setState({ world });
+      this.loadGameBridge();
 
       const token = localStorage.getItem(TOKEN_KEY);
       if (token) {
@@ -227,6 +222,78 @@ export class AppController {
     return state.player ? this.world.locations[state.player.locationKey] ?? null : null;
   }
 
+  private buildGameBridgeCallbacks(): GameBridgeCallbacks {
+    return {
+      canMove: () => {
+        const state = this.store.getState();
+        return Boolean(state.player && !state.battle && !state.dialogue);
+      },
+      isGameplayInputBlocked: () => this.isGameplayInputBlocked(this.getActiveElement()),
+      getOverlayMode: () => deriveOverlayMode(this.store.getState()),
+      hasPendingLocationStory: () => {
+        const state = this.store.getState();
+        if (!state.player || !state.world) {
+          return false;
+        }
+        const location = state.world.locations[state.player.locationKey] ?? null;
+        return hasUnreadLocationStory(state.player, location);
+      },
+      onPositionChange: (x, y, facing) => this.updatePosition(x, y, facing),
+      onSceneChange: (locationKey) => {
+        void this.changeLocation(locationKey);
+      },
+      onOpenLocationStory: () => this.openCurrentLocationStory(),
+      onInteractNpc: (npc) => this.openNpcDialogue(npc),
+      onEncounter: (zone) => {
+        void this.startEncounter(zone);
+      },
+      onFieldPromptChange: (prompt) => this.store.setState({ fieldPrompt: prompt }),
+    };
+  }
+
+  private async ensureGameBridge(): Promise<GameRuntime> {
+    if (this.game) {
+      return this.game;
+    }
+
+    if (!this.gamePromise) {
+      this.gamePromise = import("./game/GameBridge")
+        .then(async ({ createGameBridge }) => {
+          const game = await createGameBridge(this.ui.getGameContainer(), this.buildGameBridgeCallbacks());
+          this.game = game;
+          this.hasRetriedGameLoad = false;
+          if (this.gameRetryTimer !== null) {
+            window.clearTimeout(this.gameRetryTimer);
+            this.gameRetryTimer = null;
+          }
+          const state = this.store.getState();
+          game.sync(state.world, state.player, state.presence);
+          return game;
+        })
+        .catch((error) => {
+          this.gamePromise = null;
+          throw error;
+        });
+    }
+
+    return this.gamePromise;
+  }
+
+  private loadGameBridge(): void {
+    void this.ensureGameBridge().catch((error) => {
+      const message = error instanceof Error ? error.message : "게임 런타임 로딩 실패";
+      this.store.pushLog(message);
+      if (this.hasRetriedGameLoad || this.gameRetryTimer !== null) {
+        return;
+      }
+      this.hasRetriedGameLoad = true;
+      this.gameRetryTimer = window.setTimeout(() => {
+        this.gameRetryTimer = null;
+        this.loadGameBridge();
+      }, 2000);
+    });
+  }
+
   private async authenticate(mode: "login" | "register", username: string, password: string): Promise<void> {
     const normalizedUsername = username.trim();
     const validationMessage = validateAuthCredentials(normalizedUsername, password);
@@ -251,6 +318,7 @@ export class AppController {
         presence: [],
         pending: false,
       });
+      this.loadGameBridge();
       this.store.pushLog(`${normalizedUsername} ${mode === "login" ? "로그인" : "회원가입"} 성공`);
       this.presence.connect(session.token);
       this.enterPresence(session.player, false);

--- a/apps/web/src/game/GameBridge.ts
+++ b/apps/web/src/game/GameBridge.ts
@@ -1,10 +1,7 @@
-import Phaser from "phaser";
+import type Phaser from "phaser";
 import type { DialogueNpc, EncounterZone, Facing, PlayerSave, PresenceState, WorldContent } from "@rpg/game-core";
 import type { FieldPrompt, OverlayMode } from "../gameplay";
-import { BootScene } from "./BootScene";
-import { LoadingScene } from "./LoadingScene";
-import { LoginScene } from "./LoginScene";
-import { OverworldScene } from "./OverworldScene";
+import type { OverworldScene } from "./OverworldScene";
 
 type BridgeCallbacks = {
   canMove: () => boolean;
@@ -20,24 +17,45 @@ type BridgeCallbacks = {
 };
 
 export class GameBridge {
-  private readonly game: Phaser.Game;
-  private readonly loadingScene = new LoadingScene();
-  private readonly loginScene = new LoginScene();
-  private readonly overworldScene = new OverworldScene();
   private activeScene: "loading" | "login" | "overworld" = "loading";
 
-  constructor(container: HTMLElement, private readonly callbacks: BridgeCallbacks) {
-    this.game = new Phaser.Game({
-      type: Phaser.AUTO,
+  private constructor(
+    private readonly game: Phaser.Game,
+    private readonly overworldScene: OverworldScene,
+    private readonly callbacks: BridgeCallbacks,
+  ) {}
+
+  static async create(container: HTMLElement, callbacks: BridgeCallbacks): Promise<GameBridge> {
+    const [
+      PhaserModule,
+      { BootScene },
+      { LoadingScene },
+      { LoginScene },
+      { OverworldScene },
+    ] = await Promise.all([
+      import("phaser"),
+      import("./BootScene"),
+      import("./LoadingScene"),
+      import("./LoginScene"),
+      import("./OverworldScene"),
+    ]);
+
+    const loadingScene = new LoadingScene();
+    const loginScene = new LoginScene();
+    const overworldScene = new OverworldScene();
+    const game = new PhaserModule.default.Game({
+      type: PhaserModule.default.AUTO,
       parent: container,
       width: 1024,
       height: 768,
       backgroundColor: "#1f2937",
-      scene: [new BootScene(), this.loadingScene, this.loginScene, this.overworldScene],
+      scene: [new BootScene(), loadingScene, loginScene, overworldScene],
       render: {
         pixelArt: true,
       },
     });
+
+    return new GameBridge(game, overworldScene, callbacks);
   }
 
   sync(world: WorldContent | null, player: PlayerSave | null, nearbyPlayers: PresenceState[]): void {
@@ -67,4 +85,8 @@ export class GameBridge {
     this.game.scene.start(nextScene);
     this.activeScene = nextScene;
   }
+}
+
+export async function createGameBridge(container: HTMLElement, callbacks: BridgeCallbacks): Promise<GameBridge> {
+  return GameBridge.create(container, callbacks);
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -6,4 +6,25 @@ export default defineConfig({
   server: {
     port: 5173,
   },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes("node_modules/phaser")) {
+            return "phaser";
+          }
+
+          if (id.includes("node_modules/socket.io-client")) {
+            return "realtime";
+          }
+
+          if (id.includes("/packages/game-core/")) {
+            return "game-core";
+          }
+
+          return undefined;
+        },
+      },
+    },
+  },
 });


### PR DESCRIPTION
## 요약
- `AppController`에서 Phaser 런타임을 지연 로딩하도록 `GameBridge`를 async factory로 전환했습니다.
- 초기 엔트리에서 `phaser`를 선 preload하던 chunk 구성을 정리하고, 첫 로딩은 `game-core`와 `realtime`만 당겨오도록 조정했습니다.
- 런타임 chunk 로딩 실패 시 rejected promise가 고정되지 않도록 하고 1회 재시도하도록 보강했습니다.

## 세부 변경
- `AppController`의 정적 `GameBridge` import 제거 및 `loadGameBridge()`/`ensureGameBridge()` 추가
- `GameBridge`를 `createGameBridge()` 기반 async 생성 구조로 변경
- `vite.config.ts`에서 `phaser`, `realtime`, `game-core`만 명시적 chunk로 유지하고 broad `game-runtime` 규칙 제거

## 검증
- `corepack pnpm --filter @rpg/web typecheck`
- `corepack pnpm --filter @rpg/web test`
- `corepack pnpm --filter @rpg/web lint`
- `corepack pnpm --filter @rpg/web build`

## 빌드 메모
- 현재 초기 HTML의 modulepreload는 `game-core`, `realtime`만 남고 `phaser` preload는 제거됐습니다.
- `phaser` chunk 자체 크기 경고는 여전히 남지만, 이제는 오버월드 런타임 진입 시점에 지연 로딩됩니다.

Closes #19
