### PR TITLE
fix: 로그인 씬 인증 입력 키 캡처 해제

### DIFF
--- a/apps/web/src/game/BootScene.ts
+++ b/apps/web/src/game/BootScene.ts
@@ -1,5 +1,6 @@
 import Phaser from "phaser";
 import { getSceneAssetManifest } from "@rpg/game-core";
+import { INITIAL_SCENE } from "./sceneFlow";
 
 export class BootScene extends Phaser.Scene {
   constructor() {
@@ -18,6 +19,6 @@ export class BootScene extends Phaser.Scene {
   }
 
   create(): void {
-    this.scene.start("overworld");
+    this.scene.start(INITIAL_SCENE);
   }
 }

--- a/apps/web/src/game/BootScene.ts
+++ b/apps/web/src/game/BootScene.ts
@@ -3,7 +3,7 @@ import { getSceneAssetManifest } from "@rpg/game-core";
 import { INITIAL_SCENE } from "./sceneFlow";
 
 export class BootScene extends Phaser.Scene {
-  constructor() {
+  constructor(private readonly onBootComplete: () => void = () => {}) {
     super("boot");
   }
 
@@ -20,5 +20,6 @@ export class BootScene extends Phaser.Scene {
 
   create(): void {
     this.scene.start(INITIAL_SCENE);
+    this.onBootComplete();
   }
 }

--- a/apps/web/src/game/GameBridge.ts
+++ b/apps/web/src/game/GameBridge.ts
@@ -27,6 +27,11 @@ export class GameBridge {
   ) {}
 
   static async create(container: HTMLElement, callbacks: BridgeCallbacks): Promise<GameBridge> {
+    let notifyBootComplete: (() => void) | null = null;
+    const bootCompleted = new Promise<void>((resolve) => {
+      notifyBootComplete = resolve;
+    });
+
     const [
       PhaserModule,
       { BootScene },
@@ -44,17 +49,22 @@ export class GameBridge {
     const loadingScene = new LoadingScene();
     const loginScene = new LoginScene();
     const overworldScene = new OverworldScene();
+    const bootScene = new BootScene(() => {
+      notifyBootComplete?.();
+    });
     const game = new PhaserModule.default.Game({
       type: PhaserModule.default.AUTO,
       parent: container,
       width: 1024,
       height: 768,
       backgroundColor: "#1f2937",
-      scene: [new BootScene(), loadingScene, loginScene, overworldScene],
+      scene: [bootScene, loadingScene, loginScene, overworldScene],
       render: {
         pixelArt: true,
       },
     });
+
+    await bootCompleted;
 
     const bridge = new GameBridge(game, overworldScene, callbacks);
     bridge.syncGlobalCapture(bridge.activeScene);

--- a/apps/web/src/game/GameBridge.ts
+++ b/apps/web/src/game/GameBridge.ts
@@ -2,8 +2,7 @@ import type Phaser from "phaser";
 import type { DialogueNpc, EncounterZone, Facing, PlayerSave, PresenceState, WorldContent } from "@rpg/game-core";
 import type { FieldPrompt, OverlayMode } from "../gameplay";
 import type { OverworldScene } from "./OverworldScene";
-
-export type ManagedSceneKey = "loading" | "login" | "overworld";
+import { INITIAL_SCENE, shouldDisableGlobalKeyboardCapture, type ManagedSceneKey } from "./sceneFlow";
 
 type BridgeCallbacks = {
   canMove: () => boolean;
@@ -19,7 +18,7 @@ type BridgeCallbacks = {
 };
 
 export class GameBridge {
-  private activeScene: ManagedSceneKey = "loading";
+  private activeScene: ManagedSceneKey = INITIAL_SCENE;
 
   private constructor(
     private readonly game: Phaser.Game,
@@ -86,9 +85,9 @@ export class GameBridge {
       return;
     }
 
-    this.syncGlobalCapture(nextScene);
     this.game.scene.start(nextScene);
     this.activeScene = nextScene;
+    this.syncGlobalCapture(nextScene);
   }
 
   private syncGlobalCapture(activeScene: ManagedSceneKey): void {
@@ -109,8 +108,4 @@ export class GameBridge {
 
 export async function createGameBridge(container: HTMLElement, callbacks: BridgeCallbacks): Promise<GameBridge> {
   return GameBridge.create(container, callbacks);
-}
-
-export function shouldDisableGlobalKeyboardCapture(activeScene: ManagedSceneKey): boolean {
-  return activeScene !== "overworld";
 }

--- a/apps/web/src/game/GameBridge.ts
+++ b/apps/web/src/game/GameBridge.ts
@@ -3,6 +3,8 @@ import type { DialogueNpc, EncounterZone, Facing, PlayerSave, PresenceState, Wor
 import type { FieldPrompt, OverlayMode } from "../gameplay";
 import type { OverworldScene } from "./OverworldScene";
 
+export type ManagedSceneKey = "loading" | "login" | "overworld";
+
 type BridgeCallbacks = {
   canMove: () => boolean;
   isGameplayInputBlocked: () => boolean;
@@ -17,7 +19,7 @@ type BridgeCallbacks = {
 };
 
 export class GameBridge {
-  private activeScene: "loading" | "login" | "overworld" = "loading";
+  private activeScene: ManagedSceneKey = "loading";
 
   private constructor(
     private readonly game: Phaser.Game,
@@ -55,7 +57,9 @@ export class GameBridge {
       },
     });
 
-    return new GameBridge(game, overworldScene, callbacks);
+    const bridge = new GameBridge(game, overworldScene, callbacks);
+    bridge.syncGlobalCapture(bridge.activeScene);
+    return bridge;
   }
 
   sync(world: WorldContent | null, player: PlayerSave | null, nearbyPlayers: PresenceState[]): void {
@@ -82,11 +86,31 @@ export class GameBridge {
       return;
     }
 
+    this.syncGlobalCapture(nextScene);
     this.game.scene.start(nextScene);
     this.activeScene = nextScene;
+  }
+
+  private syncGlobalCapture(activeScene: ManagedSceneKey): void {
+    const keyboardManager = this.game.input.keyboard;
+    if (!keyboardManager) {
+      return;
+    }
+
+    if (shouldDisableGlobalKeyboardCapture(activeScene)) {
+      keyboardManager.preventDefault = false;
+      this.overworldScene.input.keyboard?.resetKeys();
+      return;
+    }
+
+    keyboardManager.preventDefault = true;
   }
 }
 
 export async function createGameBridge(container: HTMLElement, callbacks: BridgeCallbacks): Promise<GameBridge> {
   return GameBridge.create(container, callbacks);
+}
+
+export function shouldDisableGlobalKeyboardCapture(activeScene: ManagedSceneKey): boolean {
+  return activeScene !== "overworld";
 }

--- a/apps/web/src/game/OverworldScene.ts
+++ b/apps/web/src/game/OverworldScene.ts
@@ -90,7 +90,7 @@ export class OverworldScene extends Phaser.Scene {
     this.keySpace = this.input.keyboard!.addKey("SPACE");
     this.keyBattle = this.input.keyboard!.addKey("B");
     this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
-      this.input.keyboard?.enableGlobalCapture();
+      this.input.keyboard?.resetKeys();
       this.gameplayCaptureDisabled = false;
     });
 

--- a/apps/web/src/game/sceneFlow.ts
+++ b/apps/web/src/game/sceneFlow.ts
@@ -1,0 +1,7 @@
+export type ManagedSceneKey = "loading" | "login" | "overworld";
+
+export const INITIAL_SCENE: ManagedSceneKey = "loading";
+
+export function shouldDisableGlobalKeyboardCapture(activeScene: ManagedSceneKey): boolean {
+  return activeScene !== "overworld";
+}

--- a/apps/web/test/gameBridge.test.ts
+++ b/apps/web/test/gameBridge.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { shouldDisableGlobalKeyboardCapture } from "../src/game/GameBridge";
+
+describe("GameBridge keyboard capture", () => {
+  it("disables global capture for loading and login scenes", () => {
+    expect(shouldDisableGlobalKeyboardCapture("loading")).toBe(true);
+    expect(shouldDisableGlobalKeyboardCapture("login")).toBe(true);
+  });
+
+  it("keeps global capture enabled for overworld gameplay", () => {
+    expect(shouldDisableGlobalKeyboardCapture("overworld")).toBe(false);
+  });
+});

--- a/apps/web/test/gameBridge.test.ts
+++ b/apps/web/test/gameBridge.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { shouldDisableGlobalKeyboardCapture } from "../src/game/GameBridge";
+import { INITIAL_SCENE, shouldDisableGlobalKeyboardCapture } from "../src/game/sceneFlow";
 
-describe("GameBridge keyboard capture", () => {
+describe("scene flow", () => {
+  it("boots into the loading scene before auth or overworld", () => {
+    expect(INITIAL_SCENE).toBe("loading");
+  });
+
   it("disables global capture for loading and login scenes", () => {
     expect(shouldDisableGlobalKeyboardCapture("loading")).toBe(true);
     expect(shouldDisableGlobalKeyboardCapture("login")).toBe(true);


### PR DESCRIPTION
## 요약
- 로그인/로딩 씬에서는 Phaser 전역 키 캡처를 비활성화해서 DOM 인증 입력이 브라우저에 정상 전달되도록 수정했습니다.
- 오버월드 진입 시에만 전역 키 캡처를 다시 활성화하도록 `GameBridge` 씬 전환 흐름을 보완했습니다.
- 로그인 입력 회귀를 막기 위해 키 캡처 정책 테스트를 추가했습니다.

## 원인
`#25`에서 오버월드 내부의 게임플레이 입력 차단은 정리됐지만, 인증 전 단계에서 사용하는 `LoginScene` 전환 시점의 전역 키 캡처 해제가 빠져 있었습니다. 그 결과 비밀번호 필드처럼 DOM 입력을 사용할 때 `W/A/S/D`가 Phaser 쪽에서 먼저 소비될 수 있었습니다.

## 검증
- `corepack pnpm --filter @rpg/web typecheck`
- `corepack pnpm --filter @rpg/web test`
- `corepack pnpm --filter @rpg/web lint`
- `corepack pnpm --filter @rpg/web build`

Closes #35
