### PR TITLE
fix: 포탈 과밀 배치와 아이템 설명 UI 개선

### DIFF
--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -513,6 +513,26 @@ button {
   line-height: 1.45;
 }
 
+.dock-card span + span {
+  margin-top: 2px;
+}
+
+.dock-card .card-description {
+  color: var(--text-main);
+  font-size: 0.92rem;
+}
+
+.dock-card .card-meta,
+.dock-card .card-action {
+  color: var(--text-muted);
+}
+
+.dock-card .card-action {
+  font-family: "Space Mono", monospace;
+  font-size: 0.78rem;
+  letter-spacing: 0.02em;
+}
+
 .dock-card.accent {
   background: rgba(83, 181, 156, 0.18);
 }

--- a/apps/web/src/ui/actionCards.ts
+++ b/apps/web/src/ui/actionCards.ts
@@ -1,0 +1,46 @@
+import type { EquipmentDefinition, SkillDefinition } from "@rpg/game-core";
+
+export type ShopActionCard = {
+  title: string;
+  description: string;
+  meta: string;
+  action: string;
+};
+
+function formatAccuracy(accuracy: number): string {
+  return `명중 ${Math.round(accuracy * 100)}%`;
+}
+
+function joinSegments(segments: string[]): string {
+  return segments.filter(Boolean).join(" · ");
+}
+
+export function describeEquipmentActionCard(
+  equipment: EquipmentDefinition,
+  options: { owned: boolean; equipped: boolean },
+): ShopActionCard {
+  const metaSegments = [
+    equipment.attackBonus !== 0 ? `공격 ${equipment.attackBonus > 0 ? `+${equipment.attackBonus}` : equipment.attackBonus}` : "",
+    equipment.manaCost > 0 ? `MP ${equipment.manaCost}` : "",
+    formatAccuracy(equipment.accuracy),
+  ];
+
+  return {
+    title: equipment.name,
+    description: equipment.description,
+    meta: joinSegments(metaSegments),
+    action: options.owned ? (options.equipped ? "장착 해제/교체" : "장착") : `${equipment.cost} 코인 구매`,
+  };
+}
+
+export function describeSkillActionCard(skill: SkillDefinition, learned: boolean): ShopActionCard {
+  return {
+    title: skill.name,
+    description: skill.description,
+    meta: joinSegments([
+      `MP ${skill.manaCost}`,
+      formatAccuracy(skill.accuracy),
+    ]),
+    action: learned ? "습득 완료" : `${skill.cost} 코인 습득`,
+  };
+}

--- a/apps/web/src/ui/dom.ts
+++ b/apps/web/src/ui/dom.ts
@@ -20,6 +20,7 @@ import {
   type FloatingPanelKey,
   type FloatingPanelLayout,
 } from "./layout";
+import { describeEquipmentActionCard, describeSkillActionCard } from "./actionCards";
 
 type UiCallbacks = {
   onAuthSubmit: (mode: "login" | "register", username: string, password: string) => void;
@@ -705,10 +706,16 @@ export class DomUi {
       .map((item) => {
         const owned = player.ownedEquipmentIds.includes(item.id);
         const equippedState = player.equippedEquipmentIds.includes(item.id);
+        const card = describeEquipmentActionCard(item, {
+          owned,
+          equipped: equippedState,
+        });
         return `
           <button class="dock-card" data-equipment="${item.id}">
-            <strong>${item.name}</strong>
-            <span>${owned ? (equippedState ? "장착 해제/교체" : "장착") : `${item.cost} 코인 구매`}</span>
+            <strong>${card.title}</strong>
+            <span class="card-description">${card.description}</span>
+            <span class="card-meta">${card.meta}</span>
+            <span class="card-action">${card.action}</span>
           </button>
         `;
       })
@@ -716,10 +723,13 @@ export class DomUi {
     const skillButtons = skillsForLocation
       .map((skill) => {
         const learned = player.learnedSkillIds.includes(skill.id);
+        const card = describeSkillActionCard(skill, learned);
         return `
           <button class="dock-card" data-skill="${skill.id}">
-            <strong>${skill.name}</strong>
-            <span>${learned ? "습득 완료" : `${skill.cost} 코인 습득`}</span>
+            <strong>${card.title}</strong>
+            <span class="card-description">${card.description}</span>
+            <span class="card-meta">${card.meta}</span>
+            <span class="card-action">${card.action}</span>
           </button>
         `;
       })

--- a/apps/web/test/actionCards.test.ts
+++ b/apps/web/test/actionCards.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import type { EquipmentDefinition, SkillDefinition } from "@rpg/game-core";
+import { describeEquipmentActionCard, describeSkillActionCard } from "../src/ui/actionCards";
+
+const equipment: EquipmentDefinition = {
+  id: "equipment-bronze-sword",
+  name: "청동 검",
+  village: "시작의 마을",
+  cost: 120,
+  attackBonus: 7,
+  manaCost: 0,
+  accuracy: 0.92,
+  description: "초반 지역에서 안정적으로 쓰기 좋은 검입니다.",
+  effects: [],
+};
+
+const skill: SkillDefinition = {
+  id: "skill-fireball",
+  name: "화염구",
+  village: "시작의 마을",
+  cost: 90,
+  manaCost: 12,
+  accuracy: 0.85,
+  description: "적 하나에게 화염 피해를 주는 기본 마법입니다.",
+  effects: [],
+};
+
+describe("shop action card helpers", () => {
+  it("includes equipment descriptions and purchase state", () => {
+    const card = describeEquipmentActionCard(equipment, { owned: false, equipped: false });
+
+    expect(card.description).toBe(equipment.description);
+    expect(card.meta).toContain("공격 +7");
+    expect(card.meta).toContain("명중 92%");
+    expect(card.action).toBe("120 코인 구매");
+  });
+
+  it("uses equipped state labels for owned equipment", () => {
+    const card = describeEquipmentActionCard(equipment, { owned: true, equipped: true });
+
+    expect(card.action).toBe("장착 해제/교체");
+  });
+
+  it("includes skill descriptions and casting stats", () => {
+    const card = describeSkillActionCard(skill, false);
+
+    expect(card.description).toBe(skill.description);
+    expect(card.meta).toContain("MP 12");
+    expect(card.meta).toContain("명중 85%");
+    expect(card.action).toBe("90 코인 습득");
+  });
+});

--- a/packages/game-core/src/content/legacy.ts
+++ b/packages/game-core/src/content/legacy.ts
@@ -13,6 +13,7 @@ import type {
   WorldContent,
 } from "../types";
 import {
+  createScenePortalSlots,
   createSceneLayout,
   getSceneAssetBundle,
   getSceneLayoutId,
@@ -333,6 +334,7 @@ function buildScene(
     hasBoss,
   });
   const layout = createSceneLayout(layoutId);
+  const portalSlots = createScenePortalSlots(layout, connectionKeys.length);
 
   return {
     sceneId,
@@ -343,7 +345,7 @@ function buildScene(
     backgroundColor: areaColor(mainLocation),
     spawn: { ...layout.spawn },
     portals: connectionKeys.map((connection, index) => {
-      const slot = layout.portalSlots[index % layout.portalSlots.length]!;
+      const slot = portalSlots[index]!;
       return {
         id: toStableId("portal", `${sceneId}-${connection.toLocationKey}`),
         label: connection.label,

--- a/packages/game-core/src/content/sceneMetadata.ts
+++ b/packages/game-core/src/content/sceneMetadata.ts
@@ -19,6 +19,13 @@ type SceneLayoutTemplate = {
   collisionZones: SceneRect[];
 };
 
+export type ScenePortalSlot = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
 export const SCENE_THEME_IDS: SceneThemeId[] = [
   "village",
   "grassland",
@@ -51,6 +58,22 @@ const COMMON_TEXTURES = {
   portalTexturePath: "/assets/placeholders/actors/portal.svg",
   encounterTexturePath: "/assets/placeholders/actors/encounter.svg",
 } as const;
+
+const HORIZONTAL_PORTAL = {
+  width: 88,
+  height: 24,
+} as const;
+
+const VERTICAL_PORTAL = {
+  width: 24,
+  height: 120,
+} as const;
+
+const PORTAL_EDGE_ORDER = ["top", "right", "bottom", "left"] as const;
+const PORTAL_HORIZONTAL_PADDING = 128;
+const PORTAL_VERTICAL_PADDING = 104;
+const PORTAL_TOP_Y = 22;
+const PORTAL_LEFT_X = 58;
 
 const SCENE_LAYOUTS: Record<SceneLayoutId, SceneLayoutTemplate> = {
   town_gate: {
@@ -259,6 +282,105 @@ export function createSceneLayout(layoutId: SceneLayoutId): SceneLayoutTemplate 
     portalSlots: template.portalSlots.map((slot) => ({ ...slot })),
     collisionZones: cloneZones(template.collisionZones),
   };
+}
+
+function distributeValues(count: number, start: number, end: number): number[] {
+  if (count <= 0) {
+    return [];
+  }
+
+  if (count === 1) {
+    return [Math.round((start + end) / 2)];
+  }
+
+  return Array.from({ length: count }, (_value, index) => {
+    const ratio = index / (count - 1);
+    return Math.round(start + (end - start) * ratio);
+  });
+}
+
+function buildHorizontalPortalSlots(sceneWidth: number, sceneHeight: number, count: number, edge: "top" | "bottom"): ScenePortalSlot[] {
+  if (count <= 0) {
+    return [];
+  }
+
+  const y = edge === "top"
+    ? PORTAL_TOP_Y
+    : sceneHeight - PORTAL_TOP_Y - HORIZONTAL_PORTAL.height;
+  const minCenter = PORTAL_HORIZONTAL_PADDING + HORIZONTAL_PORTAL.width / 2;
+  const maxCenter = sceneWidth - PORTAL_HORIZONTAL_PADDING - HORIZONTAL_PORTAL.width / 2;
+
+  return distributeValues(count, minCenter, maxCenter).map((centerX) => ({
+    x: centerX - HORIZONTAL_PORTAL.width / 2,
+    y,
+    width: HORIZONTAL_PORTAL.width,
+    height: HORIZONTAL_PORTAL.height,
+  }));
+}
+
+function buildVerticalPortalSlots(sceneWidth: number, sceneHeight: number, count: number, edge: "right" | "left"): ScenePortalSlot[] {
+  if (count <= 0) {
+    return [];
+  }
+
+  const x = edge === "left"
+    ? PORTAL_LEFT_X
+    : sceneWidth - PORTAL_LEFT_X - VERTICAL_PORTAL.width;
+  const minCenter = PORTAL_VERTICAL_PADDING + VERTICAL_PORTAL.height / 2;
+  const maxCenter = sceneHeight - PORTAL_VERTICAL_PADDING - VERTICAL_PORTAL.height / 2;
+
+  return distributeValues(count, minCenter, maxCenter).map((centerY) => ({
+    x,
+    y: centerY - VERTICAL_PORTAL.height / 2,
+    width: VERTICAL_PORTAL.width,
+    height: VERTICAL_PORTAL.height,
+  }));
+}
+
+export function createScenePortalSlots(
+  layout: { width: number; height: number; portalSlots: ScenePortalSlot[] },
+  portalCount: number,
+): ScenePortalSlot[] {
+  if (portalCount <= 0) {
+    return [];
+  }
+
+  if (portalCount <= layout.portalSlots.length) {
+    return layout.portalSlots.slice(0, portalCount).map((slot) => ({ ...slot }));
+  }
+
+  const countsByEdge = {
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+  };
+
+  for (let index = 0; index < portalCount; index += 1) {
+    const edge = PORTAL_EDGE_ORDER[index % PORTAL_EDGE_ORDER.length]!;
+    countsByEdge[edge] += 1;
+  }
+
+  const slotsByEdge = {
+    top: buildHorizontalPortalSlots(layout.width, layout.height, countsByEdge.top, "top"),
+    right: buildVerticalPortalSlots(layout.width, layout.height, countsByEdge.right, "right"),
+    bottom: buildHorizontalPortalSlots(layout.width, layout.height, countsByEdge.bottom, "bottom"),
+    left: buildVerticalPortalSlots(layout.width, layout.height, countsByEdge.left, "left"),
+  };
+
+  const edgeOffsets = {
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+  };
+
+  return Array.from({ length: portalCount }, (_value, index) => {
+    const edge = PORTAL_EDGE_ORDER[index % PORTAL_EDGE_ORDER.length]!;
+    const nextSlot = slotsByEdge[edge][edgeOffsets[edge]]!;
+    edgeOffsets[edge] += 1;
+    return nextSlot;
+  });
 }
 
 export function getSceneMapJsonPath(layoutId: SceneLayoutId): string {

--- a/packages/game-core/src/validation.ts
+++ b/packages/game-core/src/validation.ts
@@ -262,6 +262,18 @@ function validateRectangleInsideScene(
   return issues;
 }
 
+function rectanglesOverlap(
+  left: Pick<CollisionZone, "x" | "y" | "width" | "height">,
+  right: Pick<CollisionZone, "x" | "y" | "width" | "height">,
+): boolean {
+  return (
+    left.x < right.x + right.width
+    && left.x + left.width > right.x
+    && left.y < right.y + right.height
+    && left.y + left.height > right.y
+  );
+}
+
 function validateEncounterZone(zone: EncounterZone, world: WorldContent, path: string): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
 
@@ -297,6 +309,17 @@ function validateLocation(location: LocationNode, key: string, world: WorldConte
 
   location.scene.portals.forEach((portal, index) => {
     issues.push(...validateRectangleInsideScene(portal, location.scene, `${path}.scene.portals[${index}]`, "Portal"));
+  });
+
+  location.scene.portals.forEach((portal, index) => {
+    location.scene.portals.slice(index + 1).forEach((otherPortal, otherIndex) => {
+      if (rectanglesOverlap(portal, otherPortal)) {
+        issues.push(issue(
+          `${path}.scene.portals[${index}]`,
+          `Portal '${portal.id}' overlaps portal '${otherPortal.id}' at portals[${index + otherIndex + 1}].`,
+        ));
+      }
+    });
   });
 
   location.scene.npcs.forEach((npc, index) => {

--- a/packages/game-core/test/content.test.ts
+++ b/packages/game-core/test/content.test.ts
@@ -5,7 +5,19 @@ import boss from "../../../game/boss.json";
 import equipment from "../../../game/equipment.json";
 import skill from "../../../game/skill.json";
 import tactics from "../../../game/tactics.json";
-import { buildWorldContentFromLegacy, validateWorldContent } from "../src";
+import { buildWorldContentFromLegacy, createSceneLayout, createScenePortalSlots, validateWorldContent } from "../src";
+
+function rectanglesOverlap(
+  left: { x: number; y: number; width: number; height: number },
+  right: { x: number; y: number; width: number; height: number },
+): boolean {
+  return (
+    left.x < right.x + right.width
+    && left.x + left.width > right.x
+    && left.y < right.y + right.height
+    && left.y + left.height > right.y
+  );
+}
 
 describe("legacy content conversion", () => {
   it("converts the current JSON dataset into valid shared world content", () => {
@@ -79,5 +91,18 @@ describe("legacy content conversion", () => {
     });
 
     expect(issues.some((entry) => entry.path.endsWith("assets.mapJsonPath"))).toBe(true);
+  });
+
+  it("creates non-overlapping portal slots when a layout needs more than four exits", () => {
+    const layout = createSceneLayout("plaza");
+    const slots = createScenePortalSlots(layout, 6);
+
+    expect(slots).toHaveLength(6);
+
+    slots.forEach((slot, index) => {
+      slots.slice(index + 1).forEach((otherSlot) => {
+        expect(rectanglesOverlap(slot, otherSlot)).toBe(false);
+      });
+    });
   });
 });


### PR DESCRIPTION
## 요약
- 연결 지점이 많은 씬에서도 포탈이 겹치지 않도록 포탈 슬롯 생성 로직을 재구성했습니다.
- 월드 콘텐츠 검증에 포탈 겹침 체크를 추가해서 이후 데이터 변경에서도 CI가 바로 잡아내도록 했습니다.
- 마을 액션 패널에서 장비와 기술의 설명, 핵심 수치, 구매/습득 상태를 함께 볼 수 있도록 UI를 개선했습니다.

## 원인
기존 씬 생성 로직은 레이아웃의 `portalSlots` 개수가 부족할 때 `%` 연산으로 기존 슬롯을 다시 사용했습니다. 그 결과 `사막::마을 입구`, `산길::마을 입구`, `심해 도시::심해 중심지`처럼 출구가 5개 이상인 지역에서 포탈과 라벨이 서로 겹쳤습니다.

장비와 기술 패널은 이름과 비용만 노출하고 있었기 때문에, 플레이어가 설명이나 효과 맥락 없이 구매 결정을 내려야 하는 상태였습니다.

## 변경 사항
- `packages/game-core`에 포탈 자동 분산 배치 헬퍼를 추가했습니다.
- 포탈 사각형끼리 겹치면 콘텐츠 검증이 실패하도록 validation 규칙을 확장했습니다.
- 액션 패널용 카드 설명 헬퍼를 분리하고, 장비/기술 카드에 설명과 메타 정보를 렌더링하도록 UI를 갱신했습니다.
- 관련 단위 테스트를 추가해 과밀 포탈 배치와 액션 카드 텍스트를 검증했습니다.

## 검증
- `corepack pnpm --filter @rpg/game-core test`
- `corepack pnpm --filter @rpg/game-core typecheck`
- `corepack pnpm --filter @rpg/web test`
- `corepack pnpm --filter @rpg/web typecheck`
- `corepack pnpm --filter @rpg/web lint`
- `corepack pnpm build`

Closes #38
Closes #37
