### PR TITLE
chore: .gitignore generated artifact rules 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,23 +1,56 @@
-.vercel
-/node_modules
-**/node_modules
+# Dependencies
+/node_modules/
+**/node_modules/
+
+# Package-manager lockfiles from non-pnpm installs
 /package-lock.json
-/.turbo
-/.playwright
-/.cache
-/.vite
-**/.vite
-/dist
-/coverage
-**/dist
-**/coverage
-/.env
-/.env.local
-/.env.*.local
+/yarn.lock
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Build outputs
+/dist/
+**/dist/
+/build/
+**/build/
+
+# Test and coverage artifacts
+/coverage/
+**/coverage/
+/.nyc_output/
+**/.nyc_output/
+/playwright-report/
+/test-results/
+/blob-report/
+
+# Tool caches
+/.turbo/
+/.cache/
+/.vite/
+**/.vite/
+/.playwright/
+playwright/.cache/
+.eslintcache
+*.tsbuildinfo
+vite.config.*.timestamp-*
+
+# Deployment / local runtime state
+.vercel/
+.omx/
+
+# Environment files; keep examples tracked
+.env
+.env.*
 **/.env
-**/.env.local
-**/.env.*.local
-!/.env.example
+**/.env.*
+!.env.example
 !**/.env.example
-playwright-report
-test-results
+
+# OS/editor noise
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
## Summary
- reorganize `.gitignore` into documented sections
- ignore common generated artifacts from pnpm/Vite/Playwright workflows
- keep project contract files such as `.env.example` and `pnpm-lock.yaml` trackable

## Validation
- `git diff --check -- .gitignore`
- `git ls-files -ci --exclude-standard`
- targeted `git check-ignore` checks for generated artifacts and env examples
