### PR TITLE
Block legacy runtime and validate realtime data

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,7 @@
+/api
+/lib
+/server.js
+/script.js
+/style.css
+/index.html
+/game

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -63,7 +63,8 @@ export async function createAppContext(options: {
       throw createRouteError(404, "not_found", "플레이어를 찾을 수 없습니다.");
     }
 
-    const player = readPlayerSave(req.body) as PlayerSave;
+    const world = await worldLoader();
+    const player = readPlayerSave(req.body, world) as PlayerSave;
     if (!assertPlayerOwnership(req, player)) {
       throw createRouteError(403, "forbidden", "다른 플레이어의 세이브를 저장할 수 없습니다.");
     }
@@ -85,7 +86,8 @@ export async function createAppContext(options: {
     },
   });
 
-  configureRealtime(io, env);
+  const realtimeWorld = await worldLoader();
+  configureRealtime(io, env, realtimeWorld);
 
   return { app, httpServer, io };
 }

--- a/apps/server/src/http/validation.ts
+++ b/apps/server/src/http/validation.ts
@@ -1,10 +1,23 @@
-import type { PlayerSave } from "@rpg/game-core";
+import type { Facing, PlayerSave, StoryState, WorldContent } from "@rpg/game-core";
+import { getMaxHp, getMaxMp, MAX_EXPERIENCE, normalizePlayerPosition } from "@rpg/game-core";
 import { createRouteError } from "./response";
 
 type CredentialsInput = {
   username: string;
   password: string;
 };
+
+const USERNAME_MIN_LENGTH = 2;
+const USERNAME_MAX_LENGTH = 24;
+const PASSWORD_MIN_LENGTH = 8;
+const PASSWORD_MAX_LENGTH = 128;
+const USERNAME_PATTERN = /^[A-Za-z0-9_-]+$/u;
+const MAX_LEVEL = 100;
+const MAX_COINS = 999_999;
+const MAX_DEFENSE = 10_000;
+const MAX_SPEED = 10_000;
+
+const FACING_VALUES = new Set<Facing>(["up", "down", "left", "right"]);
 
 function asRecord(value: unknown, message: string): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -50,23 +63,139 @@ function expectBooleanRecord(value: unknown, path: string, issues: string[]): vo
   });
 }
 
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function clampInteger(value: number, min: number, max: number): number {
+  return Math.trunc(clamp(value, min, max));
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return Array.from(new Set(values));
+}
+
+function collectValidIds(
+  value: unknown,
+  path: string,
+  validIds: Set<string>,
+  issues: string[],
+): string[] {
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+    return [];
+  }
+
+  const ids = uniqueStrings(value);
+  const invalid = ids.filter((id) => !validIds.has(id));
+  if (invalid.length > 0) {
+    issues.push(`${path} contains unknown ids: ${invalid.join(", ")}.`);
+  }
+
+  return ids;
+}
+
+function collectVisitedMainLocations(value: unknown, world: WorldContent, issues: string[]): string[] {
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+    return [];
+  }
+
+  const validMainLocations = new Set(Object.values(world.locations).map((location) => location.mainLocation));
+  const entries = uniqueStrings(value);
+  const invalid = entries.filter((entry) => !validMainLocations.has(entry));
+  if (invalid.length > 0) {
+    issues.push(`player.visitedMainLocations contains unknown locations: ${invalid.join(", ")}.`);
+  }
+
+  return entries;
+}
+
+function readStoryStateRecord(value: unknown, world: WorldContent, issues: string[]): Record<string, StoryState> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+
+  const output: Record<string, StoryState> = {};
+  Object.entries(value as Record<string, unknown>).forEach(([key, entry]) => {
+    const location = world.locations[key];
+    if (!location) {
+      issues.push(`player.storyState.${key} references an unknown location.`);
+      return;
+    }
+
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      return;
+    }
+
+    const state = entry as Record<string, unknown>;
+    output[key] = {
+      completed: Boolean(state.completed),
+      currentIndex: clampInteger(Number(state.currentIndex), 0, Math.max(0, location.story.length)),
+    };
+  });
+
+  return output;
+}
+
+function readQuestCompletion(value: unknown, world: WorldContent, issues: string[]): Record<string, boolean> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+
+  const validBossNames = new Set(
+    Object.values(world.locations)
+      .map((location) => location.bossName)
+      .filter((name): name is string => Boolean(name)),
+  );
+  const output: Record<string, boolean> = {};
+
+  Object.entries(value as Record<string, unknown>).forEach(([key, entry]) => {
+    if (!validBossNames.has(key)) {
+      issues.push(`player.questCompletion.${key} references an unknown boss.`);
+      return;
+    }
+    output[key] = Boolean(entry);
+  });
+
+  return output;
+}
+
+function baseAttackForLevel(level: number): number {
+  let attack = 10;
+  for (let currentLevel = 2; currentLevel <= level; currentLevel += 1) {
+    attack += Math.floor((currentLevel + 2) ** 2);
+  }
+  return attack;
+}
+
 export function readCredentials(body: unknown): CredentialsInput {
   const record = asRecord(body, "인증 요청 본문이 올바르지 않습니다.");
   const username = String(record.username ?? "").trim();
   const password = String(record.password ?? "");
 
-  if (username.length < 2) {
-    throw createRouteError(400, "validation_error", "사용자 이름은 2자 이상이어야 합니다.");
+  if (username.length < USERNAME_MIN_LENGTH) {
+    throw createRouteError(400, "validation_error", `사용자 이름은 ${USERNAME_MIN_LENGTH}자 이상이어야 합니다.`);
   }
 
-  if (password.length < 8) {
-    throw createRouteError(400, "validation_error", "비밀번호는 최소 8자 이상이어야 합니다.");
+  if (username.length > USERNAME_MAX_LENGTH) {
+    throw createRouteError(400, "validation_error", `사용자 이름은 ${USERNAME_MAX_LENGTH}자 이하여야 합니다.`);
+  }
+
+  if (!USERNAME_PATTERN.test(username)) {
+    throw createRouteError(400, "validation_error", "사용자 이름은 영문, 숫자, 밑줄, 하이픈만 사용할 수 있습니다.");
+  }
+
+  if (password.length < PASSWORD_MIN_LENGTH) {
+    throw createRouteError(400, "validation_error", `비밀번호는 최소 ${PASSWORD_MIN_LENGTH}자 이상이어야 합니다.`);
+  }
+
+  if (password.length > PASSWORD_MAX_LENGTH) {
+    throw createRouteError(400, "validation_error", `비밀번호는 ${PASSWORD_MAX_LENGTH}자 이하여야 합니다.`);
   }
 
   return { username, password };
 }
 
-export function readPlayerSave(body: unknown): PlayerSave {
+export function readPlayerSave(body: unknown, world: WorldContent): PlayerSave {
   const record = asRecord(body, "세이브 요청 본문이 올바르지 않습니다.");
   const player = record.player;
   const issues: string[] = [];
@@ -144,5 +273,90 @@ export function readPlayerSave(body: unknown): PlayerSave {
     throw createRouteError(400, "validation_error", "플레이어 세이브 형식이 올바르지 않습니다.", issues);
   }
 
-  return player as PlayerSave;
+  const equipmentIds = new Set(world.equipment.map((item) => item.id));
+  const skillIds = new Set(world.skills.map((skill) => skill.id));
+  const tacticIds = new Set(world.tactics.map((tactic) => tactic.id));
+  const locationKeys = new Set(Object.keys(world.locations));
+  const locationKey = String(candidate.locationKey);
+
+  if (!locationKeys.has(locationKey)) {
+    issues.push(`player.locationKey references an unknown location: ${locationKey}.`);
+  }
+
+  const visitedMainLocations = collectVisitedMainLocations(candidate.visitedMainLocations, world, issues);
+  const visitedLocationKeys = collectValidIds(candidate.visitedLocationKeys, "player.visitedLocationKeys", locationKeys, issues);
+  const ownedEquipmentIds = collectValidIds(candidate.ownedEquipmentIds, "player.ownedEquipmentIds", equipmentIds, issues);
+  const equippedEquipmentIds = collectValidIds(candidate.equippedEquipmentIds, "player.equippedEquipmentIds", equipmentIds, issues);
+  const learnedSkillIds = collectValidIds(candidate.learnedSkillIds, "player.learnedSkillIds", skillIds, issues);
+  const learnedTacticIds = collectValidIds(candidate.learnedTacticIds, "player.learnedTacticIds", tacticIds, issues);
+  const storyStateRecord = readStoryStateRecord(candidate.storyState, world, issues);
+  const questCompletion = readQuestCompletion(candidate.questCompletion, world, issues);
+
+  const unownedEquipped = equippedEquipmentIds.filter((id) => !ownedEquipmentIds.includes(id));
+  if (unownedEquipped.length > 0) {
+    issues.push(`player.equippedEquipmentIds contains unowned ids: ${unownedEquipped.join(", ")}.`);
+  }
+
+  if (!FACING_VALUES.has(candidate.facing as Facing)) {
+    issues.push("player.facing must be one of: up, down, left, right.");
+  }
+
+  if (issues.length > 0) {
+    throw createRouteError(400, "validation_error", "플레이어 세이브 내용이 월드 데이터와 맞지 않습니다.", issues);
+  }
+
+  const level = clampInteger(Number(candidate.level), 1, MAX_LEVEL);
+  const maxHp = getMaxHp(level);
+  const maxMp = getMaxMp(level);
+  const equipmentById = new Map(world.equipment.map((item) => [item.id, item]));
+  const equippedAttackBonus = equippedEquipmentIds.reduce(
+    (total, id) => total + (equipmentById.get(id)?.attackBonus ?? 0),
+    0,
+  );
+  const maxAttack = baseAttackForLevel(level) + equippedAttackBonus;
+  const safeLocation = world.locations[locationKey] ? locationKey : world.startLocationKey;
+  const safeVisitedLocationKeys = uniqueStrings([...visitedLocationKeys, safeLocation]);
+  const safeVisitedMainLocations = uniqueStrings([
+    ...visitedMainLocations,
+    world.locations[safeLocation]?.mainLocation ?? "",
+  ].filter(Boolean));
+
+  const sanitized: PlayerSave = {
+    version: 2,
+    username: String(candidate.username).trim(),
+    coins: clampInteger(Number(candidate.coins), 0, MAX_COINS),
+    experience: clampInteger(Number(candidate.experience), 0, MAX_EXPERIENCE),
+    level,
+    currentHp: clamp(Number(candidate.currentHp), 0, maxHp),
+    currentMp: clamp(Number(candidate.currentMp), 0, maxMp),
+    attack: clampInteger(Number(candidate.attack), 1, maxAttack),
+    defense: clampInteger(Number(candidate.defense), 0, MAX_DEFENSE),
+    speed: clampInteger(Number(candidate.speed), 0, MAX_SPEED),
+    accuracy: clamp(Number(candidate.accuracy), 0, 1),
+    locationKey: safeLocation,
+    position: {
+      x: Number((position as Record<string, unknown>).x),
+      y: Number((position as Record<string, unknown>).y),
+    },
+    facing: candidate.facing as Facing,
+    visitedMainLocations: safeVisitedMainLocations,
+    visitedLocationKeys: safeVisitedLocationKeys,
+    storyState: {
+      ...storyStateRecord,
+      [safeLocation]: storyStateRecord[safeLocation] ?? {
+        completed: false,
+        currentIndex: 0,
+      },
+    },
+    ownedEquipmentIds,
+    equippedEquipmentIds,
+    learnedSkillIds,
+    learnedTacticIds,
+    questCompletion,
+    flags: {
+      demonLordDefeated: Boolean((candidate.flags as Record<string, unknown>).demonLordDefeated),
+    },
+  };
+
+  return normalizePlayerPosition(sanitized, world);
 }

--- a/apps/server/src/realtime/presence.ts
+++ b/apps/server/src/realtime/presence.ts
@@ -1,5 +1,5 @@
 import type { Server } from "socket.io";
-import type { ChatMessage, Facing, PresenceState } from "@rpg/game-core";
+import type { ChatMessage, Facing, PresenceState, WorldContent } from "@rpg/game-core";
 import type { ServerEnv } from "../config/env";
 import { verifyToken } from "../http/auth";
 
@@ -13,14 +13,114 @@ type PresenceEntry = PresenceState & {
   socketId: string;
 };
 
+type SceneBounds = {
+  width: number;
+  height: number;
+};
+
+type PresencePayload = {
+  sceneId: string;
+  x: number;
+  y: number;
+  facing: Facing;
+};
+
+const FACING_VALUES = new Set<Facing>(["up", "down", "left", "right"]);
+const MAX_CHAT_LENGTH = 200;
+
 function colorFromUsername(username: string): string {
   const palette = ["#f25f5c", "#247ba0", "#70c1b3", "#ffe066", "#50514f", "#f79d65"];
   const index = Array.from(username).reduce((acc, char) => acc + char.charCodeAt(0), 0) % palette.length;
   return palette[index]!;
 }
 
-export function configureRealtime(io: Server, env: ServerEnv): void {
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function buildSceneBounds(world: WorldContent): Map<string, SceneBounds> {
+  return new Map(
+    Object.values(world.locations).map((location) => [
+      location.scene.sceneId,
+      {
+        width: location.scene.width,
+        height: location.scene.height,
+      },
+    ]),
+  );
+}
+
+function isFacing(value: unknown): value is Facing {
+  return typeof value === "string" && FACING_VALUES.has(value as Facing);
+}
+
+function isCoordinateInsideScene(value: unknown, max: number): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= max;
+}
+
+function readPresencePayload(payload: unknown, sceneBounds: Map<string, SceneBounds>): PresencePayload | null {
+  const record = asRecord(payload);
+  if (!record || typeof record.sceneId !== "string") {
+    return null;
+  }
+
+  const bounds = sceneBounds.get(record.sceneId);
+  if (!bounds) {
+    return null;
+  }
+
+  if (!isCoordinateInsideScene(record.x, bounds.width) || !isCoordinateInsideScene(record.y, bounds.height)) {
+    return null;
+  }
+
+  if (!isFacing(record.facing)) {
+    return null;
+  }
+
+  return {
+    sceneId: record.sceneId,
+    x: record.x,
+    y: record.y,
+    facing: record.facing,
+  };
+}
+
+function readPositionPayload(payload: unknown, bounds: SceneBounds): Omit<PresencePayload, "sceneId"> | null {
+  const record = asRecord(payload);
+  if (!record) {
+    return null;
+  }
+
+  if (!isCoordinateInsideScene(record.x, bounds.width) || !isCoordinateInsideScene(record.y, bounds.height)) {
+    return null;
+  }
+
+  if (!isFacing(record.facing)) {
+    return null;
+  }
+
+  return {
+    x: record.x,
+    y: record.y,
+    facing: record.facing,
+  };
+}
+
+function readChatText(payload: unknown): string | null {
+  const record = asRecord(payload);
+  const text = typeof record?.text === "string" ? record.text.trim() : "";
+  if (text.length === 0 || text.length > MAX_CHAT_LENGTH) {
+    return null;
+  }
+  return text;
+}
+
+export function configureRealtime(io: Server, env: ServerEnv, world: WorldContent): void {
   const presenceByScene = new Map<string, Map<string, PresenceEntry>>();
+  const sceneBounds = buildSceneBounds(world);
 
   const serializeRoom = (room: Map<string, PresenceEntry>): PresenceState[] =>
     Array.from(room.values()).map((entry) => ({
@@ -101,16 +201,32 @@ export function configureRealtime(io: Server, env: ServerEnv): void {
       socket.to(sceneId).emit(hadExisting ? "presence:update" : "presence:joined", state);
     };
 
-    socket.on("presence:join", (payload: { sceneId: string; x: number; y: number; facing: Facing }) => {
-      joinScene(payload.sceneId, payload.x, payload.y, payload.facing);
+    socket.on("presence:join", (payload: unknown) => {
+      const nextPresence = readPresencePayload(payload, sceneBounds);
+      if (!nextPresence) {
+        return;
+      }
+      joinScene(nextPresence.sceneId, nextPresence.x, nextPresence.y, nextPresence.facing);
     });
 
-    socket.on("scene:change", (payload: { sceneId: string; x: number; y: number; facing: Facing }) => {
-      joinScene(payload.sceneId, payload.x, payload.y, payload.facing);
+    socket.on("scene:change", (payload: unknown) => {
+      const nextPresence = readPresencePayload(payload, sceneBounds);
+      if (!nextPresence) {
+        return;
+      }
+      joinScene(nextPresence.sceneId, nextPresence.x, nextPresence.y, nextPresence.facing);
     });
 
-    socket.on("presence:update", (payload: { x: number; y: number; facing: Facing }) => {
+    socket.on("presence:update", (payload: unknown) => {
       if (!data.sceneId) {
+        return;
+      }
+      const bounds = sceneBounds.get(data.sceneId);
+      if (!bounds) {
+        return;
+      }
+      const nextPosition = readPositionPayload(payload, bounds);
+      if (!nextPosition) {
         return;
       }
       const room = presenceByScene.get(data.sceneId);
@@ -120,7 +236,7 @@ export function configureRealtime(io: Server, env: ServerEnv): void {
       }
       const next: PresenceEntry = {
         ...current,
-        ...payload,
+        ...nextPosition,
         updatedAt: new Date().toISOString(),
         socketId: socket.id,
       };
@@ -136,12 +252,12 @@ export function configureRealtime(io: Server, env: ServerEnv): void {
       } satisfies PresenceState);
     });
 
-    socket.on("chat:send", (payload: { text: string }) => {
+    socket.on("chat:send", (payload: unknown) => {
       if (!data.sceneId) {
         return;
       }
-      const text = String(payload.text ?? "").trim();
-      if (text.length === 0 || text.length > 200) {
+      const text = readChatText(payload);
+      if (!text) {
         return;
       }
 

--- a/apps/server/test/api.test.ts
+++ b/apps/server/test/api.test.ts
@@ -6,9 +6,44 @@ import { createAppContext } from "../src/app";
 import { MemoryUserRepository } from "../src/storage/memoryRepository";
 
 function createWorld(): WorldContent {
+  const startLocationKey = "시작의 마을::마을 입구";
   return {
-    startLocationKey: "시작의 마을::마을 입구",
-    locations: {},
+    startLocationKey,
+    locations: {
+      [startLocationKey]: {
+        key: startLocationKey,
+        mainLocation: "시작의 마을",
+        subLocation: "마을 입구",
+        story: [],
+        connections: [],
+        scene: {
+          sceneId: "scene-start",
+          themeId: "village",
+          width: 1024,
+          height: 768,
+          tileSize: 32,
+          backgroundColor: "#10231b",
+          spawn: { x: 512, y: 636 },
+          portals: [],
+          npcs: [],
+          encounterZones: [],
+          collisionZones: [],
+          assets: {
+            layoutId: "town_gate",
+            mapJsonPath: "/maps/test.json",
+            terrainTexturePath: "/terrain.svg",
+            propsTexturePath: "/props.svg",
+            playerTexturePath: "/player.svg",
+            remotePlayerTexturePath: "/remote.svg",
+            npcTexturePath: "/npc.svg",
+            portalTexturePath: "/portal.svg",
+            encounterTexturePath: "/encounter.svg",
+            license: "placeholder",
+            attribution: "test",
+          },
+        },
+      },
+    },
     equipment: [],
     skills: [],
     tactics: [],
@@ -204,6 +239,11 @@ describe("http api", () => {
       },
     });
 
+    await agent
+      .post("/auth/register")
+      .send({ username: "<script>", password: "secret123" })
+      .expect(400);
+
     const register = await agent
       .post("/auth/register")
       .send({ username: "hero", password: "secret123" })
@@ -221,6 +261,24 @@ describe("http api", () => {
       .expect(400);
 
     expect(malformedSave.body).toMatchObject({
+      success: false,
+      error: {
+        code: "validation_error",
+      },
+    });
+
+    const unknownContentSave = await agent
+      .post("/player/save")
+      .set("Authorization", `Bearer ${registerPayload.data.token}`)
+      .send({
+        player: {
+          ...createStarterPlayer("hero", world),
+          ownedEquipmentIds: ["missing-equipment"],
+        },
+      })
+      .expect(400);
+
+    expect(unknownContentSave.body).toMatchObject({
       success: false,
       error: {
         code: "validation_error",

--- a/apps/server/test/realtime.test.ts
+++ b/apps/server/test/realtime.test.ts
@@ -8,9 +8,44 @@ import { signToken } from "../src/http/auth";
 import { MemoryUserRepository } from "../src/storage/memoryRepository";
 
 function createWorld(): WorldContent {
+  const startLocationKey = "시작의 마을::마을 입구";
   return {
-    startLocationKey: "시작의 마을::마을 입구",
-    locations: {},
+    startLocationKey,
+    locations: {
+      [startLocationKey]: {
+        key: startLocationKey,
+        mainLocation: "시작의 마을",
+        subLocation: "마을 입구",
+        story: [],
+        connections: [],
+        scene: {
+          sceneId: "scene-start",
+          themeId: "village",
+          width: 1024,
+          height: 768,
+          tileSize: 32,
+          backgroundColor: "#10231b",
+          spawn: { x: 512, y: 636 },
+          portals: [],
+          npcs: [],
+          encounterZones: [],
+          collisionZones: [],
+          assets: {
+            layoutId: "town_gate",
+            mapJsonPath: "/maps/test.json",
+            terrainTexturePath: "/terrain.svg",
+            propsTexturePath: "/props.svg",
+            playerTexturePath: "/player.svg",
+            remotePlayerTexturePath: "/remote.svg",
+            npcTexturePath: "/npc.svg",
+            portalTexturePath: "/portal.svg",
+            encounterTexturePath: "/encounter.svg",
+            license: "placeholder",
+            attribution: "test",
+          },
+        },
+      },
+    },
     equipment: [],
     skills: [],
     tactics: [],
@@ -112,6 +147,85 @@ describe("realtime presence", () => {
       const leftEvent = onceEvent<string>(socketB, "presence:left");
       socketA.disconnect();
       expect(await leftEvent).toBe("hero-a");
+    } finally {
+      sockets.forEach((socket) => socket.disconnect());
+      await new Promise<void>((resolve, reject) => context.httpServer.close((error) => (error ? reject(error) : resolve())));
+    }
+  }, 15_000);
+
+  it("ignores malformed presence and chat payloads", async () => {
+    const repository = new MemoryUserRepository();
+    const world = createWorld();
+    const env = {
+      runtimeMode: "test" as const,
+      port: 0,
+      clientOrigin: "http://localhost:5173",
+      jwtSecret: "0123456789abcdef0123456789abcdef",
+      jwtExpiresIn: "7d",
+      passwordHashRounds: 10,
+      storageDriver: "memory" as const,
+    };
+
+    await repository.saveAccount({
+      username: "hero-a",
+      passwordHash: "plain",
+      player: createStarterPlayer("hero-a", world),
+    });
+    await repository.saveAccount({
+      username: "hero-b",
+      passwordHash: "plain",
+      player: createStarterPlayer("hero-b", world),
+    });
+
+    const context = await createAppContext({
+      env,
+      repository,
+      worldLoader: async () => world,
+    });
+
+    await new Promise<void>((resolve) => context.httpServer.listen(0, resolve));
+    const address = context.httpServer.address() as AddressInfo;
+    const baseUrl = `http://127.0.0.1:${address.port}`;
+
+    const sockets: ClientSocket[] = [];
+
+    try {
+      const observer = await connectClient(baseUrl, signToken(env, "hero-b"));
+      const actor = await connectClient(baseUrl, signToken(env, "hero-a"));
+      sockets.push(observer, actor);
+
+      const observerSnapshot = onceEvent<PresenceState[]>(observer, "presence:snapshot");
+      observer.emit("presence:join", { sceneId: "scene-start", x: 50, y: 60, facing: "left" });
+      await observerSnapshot;
+
+      let joined: PresenceState | null = null;
+      observer.on("presence:joined", (presence) => {
+        joined = presence as PresenceState;
+      });
+      actor.emit("presence:join", { sceneId: "unknown-scene", x: 10, y: 20, facing: "down" });
+      await waitForTick();
+      expect(joined).toBeNull();
+
+      const joinedByObserver = onceEvent<PresenceState>(observer, "presence:joined");
+      const actorSnapshot = onceEvent<PresenceState[]>(actor, "presence:snapshot");
+      actor.emit("presence:join", { sceneId: "scene-start", x: 10, y: 20, facing: "down" });
+      await Promise.all([joinedByObserver, actorSnapshot]);
+
+      let update: PresenceState | null = null;
+      observer.on("presence:update", (presence) => {
+        update = presence as PresenceState;
+      });
+      actor.emit("presence:update", { x: 5000, y: 20, facing: "down" });
+      await waitForTick();
+      expect(update).toBeNull();
+
+      let chat: { text: string } | null = null;
+      observer.on("chat:message", (message) => {
+        chat = message as { text: string };
+      });
+      actor.emit("chat:send", { text: "x".repeat(201) });
+      await waitForTick();
+      expect(chat).toBeNull();
     } finally {
       sockets.forEach((socket) => socket.disconnect());
       await new Promise<void>((resolve, reject) => context.httpServer.close((error) => (error ? reject(error) : resolve())));

--- a/apps/web/src/auth.ts
+++ b/apps/web/src/auth.ts
@@ -1,11 +1,21 @@
 export const AUTH_USERNAME_MIN_LENGTH = 2;
+export const AUTH_USERNAME_MAX_LENGTH = 24;
 export const AUTH_PASSWORD_MIN_LENGTH = 8;
+const USERNAME_PATTERN = /^[A-Za-z0-9_-]+$/u;
 
 export function validateAuthCredentials(username: string, password: string): string | null {
   const normalizedUsername = username.trim();
 
   if (normalizedUsername.length < AUTH_USERNAME_MIN_LENGTH) {
     return `사용자 이름은 ${AUTH_USERNAME_MIN_LENGTH}자 이상이어야 합니다.`;
+  }
+
+  if (normalizedUsername.length > AUTH_USERNAME_MAX_LENGTH) {
+    return `사용자 이름은 ${AUTH_USERNAME_MAX_LENGTH}자 이하여야 합니다.`;
+  }
+
+  if (!USERNAME_PATTERN.test(normalizedUsername)) {
+    return "사용자 이름은 영문, 숫자, 밑줄, 하이픈만 사용할 수 있습니다.";
   }
 
   if (password.length < AUTH_PASSWORD_MIN_LENGTH) {

--- a/apps/web/src/ui/dom.ts
+++ b/apps/web/src/ui/dom.ts
@@ -6,7 +6,7 @@ import type {
   SkillDefinition,
   TacticDefinition,
 } from "@rpg/game-core";
-import { AUTH_PASSWORD_MIN_LENGTH, AUTH_USERNAME_MIN_LENGTH } from "../auth";
+import { AUTH_PASSWORD_MIN_LENGTH, AUTH_USERNAME_MAX_LENGTH, AUTH_USERNAME_MIN_LENGTH } from "../auth";
 import type { AppState } from "../state/store";
 import {
   clampFloatingPanelLayout,
@@ -48,6 +48,15 @@ type LayoutGesture =
     pointerId: number;
     mode: "resize";
   };
+
+function escapeHtml(value: unknown): string {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
 
 export class DomUi {
   private readonly root: HTMLElement;
@@ -520,15 +529,18 @@ export class DomUi {
     bodyClassName?: string;
   }): string {
     const headingTag = options.titleTag ?? "h2";
+    const eyebrow = escapeHtml(options.eyebrow);
+    const title = escapeHtml(options.title);
+    const subtitle = options.subtitle ? escapeHtml(options.subtitle) : "";
 
     return `
       <div class="panel-shell">
         <div class="panel-shell-header">
           <div class="panel-shell-copy">
-            <div class="eyebrow">${options.eyebrow}</div>
+            <div class="eyebrow">${eyebrow}</div>
             <div class="panel-shell-heading">
-              <${headingTag}>${options.title}</${headingTag}>
-              ${options.subtitle ? `<p class="panel-shell-subtitle">${options.subtitle}</p>` : ""}
+              <${headingTag}>${title}</${headingTag}>
+              ${subtitle ? `<p class="panel-shell-subtitle">${subtitle}</p>` : ""}
             </div>
           </div>
           <div class="panel-shell-controls" data-no-panel-drag>
@@ -537,7 +549,7 @@ export class DomUi {
               class="ghost panel-toggle-button"
               type="button"
               data-panel-toggle
-              data-panel-title="${options.title}"
+              data-panel-title="${title}"
             >
               ${this.isPanelCollapsed(options.key) ? "펼치기" : "접기"}
             </button>
@@ -589,7 +601,15 @@ export class DomUi {
         <form class="auth-form">
           <label>
             아이디
-            <input name="username" autocomplete="username" minlength="${AUTH_USERNAME_MIN_LENGTH}" required ${disabled} />
+            <input
+              name="username"
+              autocomplete="username"
+              minlength="${AUTH_USERNAME_MIN_LENGTH}"
+              maxlength="${AUTH_USERNAME_MAX_LENGTH}"
+              pattern="[A-Za-z0-9_-]+"
+              required
+              ${disabled}
+            />
           </label>
           <label>
             비밀번호
@@ -602,7 +622,7 @@ export class DomUi {
               ${disabled}
             />
           </label>
-          <p class="panel-note">아이디는 ${AUTH_USERNAME_MIN_LENGTH}자 이상, 비밀번호는 ${AUTH_PASSWORD_MIN_LENGTH}자 이상이어야 합니다.</p>
+          <p class="panel-note">아이디는 ${AUTH_USERNAME_MIN_LENGTH}-${AUTH_USERNAME_MAX_LENGTH}자의 영문, 숫자, 밑줄, 하이픈만 사용할 수 있고, 비밀번호는 ${AUTH_PASSWORD_MIN_LENGTH}자 이상이어야 합니다.</p>
           <button type="submit" class="primary" ${disabled}>
             ${state.pending ? "처리 중..." : state.authMode === "login" ? "접속하기" : "모험 시작"}
           </button>
@@ -650,10 +670,10 @@ export class DomUi {
         <div class="context-card ${prompt.tone}">
           <div>
             <div class="eyebrow">FIELD PROMPT</div>
-            <h3>${prompt.title}</h3>
-            <p>${prompt.body}</p>
+            <h3>${escapeHtml(prompt.title)}</h3>
+            <p>${escapeHtml(prompt.body)}</p>
           </div>
-          <span class="pill">${prompt.actionLabel}</span>
+          <span class="pill">${escapeHtml(prompt.actionLabel)}</span>
         </div>
       ` : ""}
     `;
@@ -711,11 +731,11 @@ export class DomUi {
           equipped: equippedState,
         });
         return `
-          <button class="dock-card" data-equipment="${item.id}">
-            <strong>${card.title}</strong>
-            <span class="card-description">${card.description}</span>
-            <span class="card-meta">${card.meta}</span>
-            <span class="card-action">${card.action}</span>
+          <button class="dock-card" data-equipment="${escapeHtml(item.id)}">
+            <strong>${escapeHtml(card.title)}</strong>
+            <span class="card-description">${escapeHtml(card.description)}</span>
+            <span class="card-meta">${escapeHtml(card.meta)}</span>
+            <span class="card-action">${escapeHtml(card.action)}</span>
           </button>
         `;
       })
@@ -725,17 +745,17 @@ export class DomUi {
         const learned = player.learnedSkillIds.includes(skill.id);
         const card = describeSkillActionCard(skill, learned);
         return `
-          <button class="dock-card" data-skill="${skill.id}">
-            <strong>${card.title}</strong>
-            <span class="card-description">${card.description}</span>
-            <span class="card-meta">${card.meta}</span>
-            <span class="card-action">${card.action}</span>
+          <button class="dock-card" data-skill="${escapeHtml(skill.id)}">
+            <strong>${escapeHtml(card.title)}</strong>
+            <span class="card-description">${escapeHtml(card.description)}</span>
+            <span class="card-meta">${escapeHtml(card.meta)}</span>
+            <span class="card-action">${escapeHtml(card.action)}</span>
           </button>
         `;
       })
       .join("");
     const equippedPills = equipped.length > 0
-      ? equipped.map((item) => `<span class="pill">${item.name}</span>`).join("")
+      ? equipped.map((item) => `<span class="pill">${escapeHtml(item.name)}</span>`).join("")
       : `<span class="pill muted">장착 없음</span>`;
 
     const hasContextActions = restingVisible || equipmentButtons || skillButtons;
@@ -746,7 +766,7 @@ export class DomUi {
       title: currentLocation.subLocation,
       controls: `
         <div class="dock-summary">
-          <span class="pill">${currentLocation.mainLocation}</span>
+          <span class="pill">${escapeHtml(currentLocation.mainLocation)}</span>
           ${equippedPills}
         </div>
       `,
@@ -759,8 +779,8 @@ export class DomUi {
           ${battle ? `<div class="dock-card static danger"><strong>전투 진행 중</strong><span>오른쪽 전투 오버레이에서 행동을 선택하세요.</span></div>` : ""}
           ${battleReport ? `
             <div class="dock-card static ${battleReport.outcome === "enemy_win" ? "danger" : "accent"} report-card">
-              <strong>${battleReport.title}</strong>
-              <span>${battleReport.summary}</span>
+              <strong>${escapeHtml(battleReport.title)}</strong>
+              <span>${escapeHtml(battleReport.summary)}</span>
               <span>최근 전투 로그 ${battleReport.lines.length}개가 오른쪽 패널에 반영되었습니다.</span>
             </div>
           ` : ""}
@@ -799,7 +819,7 @@ export class DomUi {
       title: state.dialogue.title,
       controls: `<span class="pill">${state.dialogue.index + 1} / ${state.dialogue.lines.length}</span>`,
       body: `
-        <p class="dialogue-line">${currentLine}</p>
+        <p class="dialogue-line">${escapeHtml(currentLine)}</p>
         <div class="dialogue-footer">
           <p class="panel-note">Space 또는 Enter 로 계속 진행할 수 있습니다.</p>
           <button class="primary" data-dialogue-next>${state.dialogue.index >= state.dialogue.lines.length - 1 ? "닫기" : "다음"}</button>
@@ -848,7 +868,7 @@ export class DomUi {
           <h3>특수 기술</h3>
           ${skills.map((skill) => `
             <button data-battle-skill="${skill.id}" ${battle.player.currentMp < skill.manaCost ? "disabled" : ""}>
-              <strong>${skill.name}</strong>
+              <strong>${escapeHtml(skill.name)}</strong>
               <span>MP ${skill.manaCost}</span>
             </button>
           `).join("") || `<p class="panel-note">습득한 기술이 없습니다.</p>`}
@@ -857,14 +877,14 @@ export class DomUi {
           <h3>전술</h3>
           ${tactics.map((tactic) => `
             <button data-battle-tactic="${tactic.id}">
-              <strong>${tactic.name}</strong>
-              <span>${tactic.description}</span>
+              <strong>${escapeHtml(tactic.name)}</strong>
+              <span>${escapeHtml(tactic.description)}</span>
             </button>
           `).join("") || `<p class="panel-note">습득한 전술이 없습니다.</p>`}
         </div>
         <div class="action-stack battle-feed">
           <h3>최근 전황</h3>
-          ${battle.log.slice(-6).map((entry) => `<div class="battle-feed-item">${entry}</div>`).join("")}
+          ${battle.log.slice(-6).map((entry) => `<div class="battle-feed-item">${escapeHtml(entry)}</div>`).join("")}
         </div>
       `,
     });
@@ -895,16 +915,16 @@ export class DomUi {
       controls: `<span class="status-pill ${state.connectionStatus}">${nearbyPlayers.length} nearby</span>`,
       body: `
         <div class="presence-strip">
-          ${nearbyPlayers.map((presence) => `<span class="pill">${presence.username}</span>`).join("") || `<span class="pill muted">같은 씬의 다른 유저 없음</span>`}
+          ${nearbyPlayers.map((presence) => `<span class="pill">${escapeHtml(presence.username)}</span>`).join("") || `<span class="pill muted">같은 씬의 다른 유저 없음</span>`}
         </div>
         <div class="chat-list">
           ${state.chatMessages
             .slice(-8)
-            .map((message) => `<div class="chat-item"><strong>${message.username}</strong><span>${message.text}</span></div>`)
+            .map((message) => `<div class="chat-item"><strong>${escapeHtml(message.username)}</strong><span>${escapeHtml(message.text)}</span></div>`)
             .join("") || `<p class="panel-note">${state.connectionStatus === "online" ? "같은 씬의 유저에게 말을 걸 수 있습니다." : "실시간 연결이 복구되면 채팅이 다시 활성화됩니다."}</p>`}
         </div>
         <form class="chat-form">
-          <input name="text" placeholder="${chatPlaceholder}" ${canChat ? "" : "disabled"} />
+          <input name="text" placeholder="${escapeHtml(chatPlaceholder)}" ${canChat ? "" : "disabled"} />
           <button type="submit" class="primary" ${canChat ? "" : "disabled"}>전송</button>
         </form>
       `,
@@ -930,7 +950,7 @@ export class DomUi {
       controls: `<span class="pill">${Math.min(logs.length, 6)} entries</span>`,
       body: `
         <div class="log-list">
-          ${logs.slice(0, 6).map((entry) => `<div class="log-item">${entry}</div>`).join("") || `<p class="panel-note">저장, 이동, 전투 결과가 여기에 쌓입니다.</p>`}
+          ${logs.slice(0, 6).map((entry) => `<div class="log-item">${escapeHtml(entry)}</div>`).join("") || `<p class="panel-note">저장, 이동, 전투 결과가 여기에 쌓입니다.</p>`}
         </div>
       `,
     });

--- a/apps/web/test/auth.test.ts
+++ b/apps/web/test/auth.test.ts
@@ -7,6 +7,10 @@ describe("web auth validation", () => {
     expect(validateAuthCredentials("a", "password123")).toBe("사용자 이름은 2자 이상이어야 합니다.");
   });
 
+  it("rejects usernames that could be interpreted as markup", () => {
+    expect(validateAuthCredentials("<script>", "password123")).toBe("사용자 이름은 영문, 숫자, 밑줄, 하이픈만 사용할 수 있습니다.");
+  });
+
   it("rejects passwords shorter than the minimum length", () => {
     expect(validateAuthCredentials("tester", "short")).toBe("비밀번호는 최소 8자 이상이어야 합니다.");
   });

--- a/scripts/security/audit-legacy-runtime.mjs
+++ b/scripts/security/audit-legacy-runtime.mjs
@@ -5,6 +5,29 @@ import { join, relative, resolve } from "node:path";
 const LEGACY_TARGETS = ["api", "lib", "server.js", "script.js", "vercel.json"];
 const SECRET_PATTERN = /\b(MONGODB_URI|JWT_SECRET|STORAGE_DRIVER|CLIENT_ORIGIN|JWT_EXPIRES_IN|BCRYPT_SALT_ROUNDS|PORT)\b/u;
 
+function normalizeIgnoreEntry(entry) {
+  return entry.trim().replace(/^\/+|\/+$/gu, "");
+}
+
+function readVercelIgnoredTargets(rootDir) {
+  const ignorePath = resolve(rootDir, ".vercelignore");
+  if (!existsSync(ignorePath)) {
+    return new Set();
+  }
+
+  return new Set(
+    readFileSync(ignorePath, "utf8")
+      .split(/\r?\n/u)
+      .map((entry) => entry.trim())
+      .filter((entry) => entry && !entry.startsWith("#"))
+      .map(normalizeIgnoreEntry),
+  );
+}
+
+function isVercelIgnored(target, ignoredTargets) {
+  return ignoredTargets.has(normalizeIgnoreEntry(target));
+}
+
 function walkFiles(targetPath) {
   const stats = statSync(targetPath);
   if (stats.isFile()) {
@@ -28,8 +51,13 @@ function findMatches(filePath) {
 const rootDir = resolve(fileURLToPath(new URL("../..", import.meta.url)));
 const strictMode = process.argv.includes("--strict");
 const findings = [];
+const ignoredTargets = readVercelIgnoredTargets(rootDir);
 
 for (const target of LEGACY_TARGETS) {
+  if (isVercelIgnored(target, ignoredTargets)) {
+    continue;
+  }
+
   const absolutePath = resolve(rootDir, target);
   if (!existsSync(absolutePath)) {
     continue;

--- a/vercel.json
+++ b/vercel.json
@@ -1,20 +1,12 @@
 {
-  "version": 2,
-  "builds": [
-    { "src": "api/**/*.js", "use": "@vercel/node" },
-    { "src": "server.js", "use": "@vercel/node" },
-    { "src": "*.js", "use": "@vercel/static" },
-    { "src": "*.html", "use": "@vercel/static" },
-    { "src": "*.css", "use": "@vercel/static" },
-    { "src": "game/**/*", "use": "@vercel/static" }
-  ],
-  "routes": [
-    { "src": "/api/login", "dest": "/api/login.js" },
-    { "src": "/api/save", "dest": "/api/save.js" },
-    { "src": "/api/(.*)", "dest": "/api/$1.js" },
-    { "src": "/game/(.*)", "dest": "/game/$1" },
-    { "src": "/(.*\\.(js|css|html|json))", "dest": "/$1" },
-    { "src": "/", "dest": "/index.html" },
-    { "src": "/(.*)", "dest": "/$1" }
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "corepack pnpm install --frozen-lockfile",
+  "buildCommand": "corepack pnpm --filter @rpg/web build",
+  "outputDirectory": "apps/web/dist",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
   ]
 }


### PR DESCRIPTION
Summary: Replaced Vercel legacy runtime deployment with the active web build and ignored archived entrypoints; escaped dynamic UI text and tightened username validation; added server-side validation for save payloads and realtime presence/chat payloads. Verification: corepack pnpm -r test; corepack pnpm -r typecheck; corepack pnpm -r lint; corepack pnpm -r build; corepack pnpm security:audit-legacy-runtime --strict; git diff --cached --check. Closes #41. Closes #42. Closes #43. Closes #44.