### PR TITLE
Add equipment slot loadout support

### DIFF
--- a/apps/server/src/http/validation.ts
+++ b/apps/server/src/http/validation.ts
@@ -1,5 +1,12 @@
-import type { Facing, PlayerSave, StoryState, WorldContent } from "@rpg/game-core";
-import { getMaxHp, getMaxMp, MAX_EXPERIENCE, normalizePlayerPosition } from "@rpg/game-core";
+import type { EquipmentDefinition, Facing, PlayerSave, StoryState, WorldContent } from "@rpg/game-core";
+import {
+  getMaxHp,
+  getMaxMp,
+  MAX_EXPERIENCE,
+  normalizeEquippedEquipmentIds,
+  normalizePlayerPosition,
+  sumEquipmentAttackBonus,
+} from "@rpg/game-core";
 import { createRouteError } from "./response";
 
 type CredentialsInput = {
@@ -297,6 +304,12 @@ export function readPlayerSave(body: unknown, world: WorldContent): PlayerSave {
     issues.push(`player.equippedEquipmentIds contains unowned ids: ${unownedEquipped.join(", ")}.`);
   }
 
+  const equipmentById: Record<string, EquipmentDefinition> = Object.fromEntries(world.equipment.map((item) => [item.id, item]));
+  const normalizedEquippedEquipmentIds = normalizeEquippedEquipmentIds(equippedEquipmentIds, equipmentById);
+  if (normalizedEquippedEquipmentIds.length !== equippedEquipmentIds.length) {
+    issues.push("player.equippedEquipmentIds contains more than one item for the same equipment slot.");
+  }
+
   if (!FACING_VALUES.has(candidate.facing as Facing)) {
     issues.push("player.facing must be one of: up, down, left, right.");
   }
@@ -308,11 +321,7 @@ export function readPlayerSave(body: unknown, world: WorldContent): PlayerSave {
   const level = clampInteger(Number(candidate.level), 1, MAX_LEVEL);
   const maxHp = getMaxHp(level);
   const maxMp = getMaxMp(level);
-  const equipmentById = new Map(world.equipment.map((item) => [item.id, item]));
-  const equippedAttackBonus = equippedEquipmentIds.reduce(
-    (total, id) => total + (equipmentById.get(id)?.attackBonus ?? 0),
-    0,
-  );
+  const equippedAttackBonus = sumEquipmentAttackBonus(normalizedEquippedEquipmentIds, equipmentById);
   const maxAttack = baseAttackForLevel(level) + equippedAttackBonus;
   const safeLocation = world.locations[locationKey] ? locationKey : world.startLocationKey;
   const safeVisitedLocationKeys = uniqueStrings([...visitedLocationKeys, safeLocation]);
@@ -349,7 +358,7 @@ export function readPlayerSave(body: unknown, world: WorldContent): PlayerSave {
       },
     },
     ownedEquipmentIds,
-    equippedEquipmentIds,
+    equippedEquipmentIds: normalizedEquippedEquipmentIds,
     learnedSkillIds,
     learnedTacticIds,
     questCompletion,

--- a/apps/server/test/api.test.ts
+++ b/apps/server/test/api.test.ts
@@ -1,9 +1,27 @@
 import request from "supertest";
 import { describe, expect, it } from "vitest";
-import type { ApiResponse, BootstrapPayload, PlayerPayload, SessionPayload, WorldContent } from "@rpg/game-core";
+import type { ApiResponse, BootstrapPayload, EquipmentDefinition, PlayerPayload, SessionPayload, WorldContent } from "@rpg/game-core";
 import { createStarterPlayer } from "@rpg/game-core";
 import { createAppContext } from "../src/app";
 import { MemoryUserRepository } from "../src/storage/memoryRepository";
+
+const TEST_EQUIPMENT_TEXTURE = "/assets/generated/items/item-village-sword.png";
+
+function makeEquipment(id: string, slot: EquipmentDefinition["slot"], attackBonus: number): EquipmentDefinition {
+  return {
+    id,
+    itemType: "equipment",
+    slot,
+    name: id,
+    texturePath: TEST_EQUIPMENT_TEXTURE,
+    cost: 0,
+    attackBonus,
+    manaCost: 0,
+    accuracy: 0.8,
+    description: id,
+    effects: [],
+  };
+}
 
 function createWorld(): WorldContent {
   const startLocationKey = "시작의 마을::마을 입구";
@@ -44,7 +62,10 @@ function createWorld(): WorldContent {
         },
       },
     },
-    equipment: [],
+    equipment: [
+      makeEquipment("equipment-sword", "weapon", 5),
+      makeEquipment("equipment-bow", "weapon", 7),
+    ],
     skills: [],
     tactics: [],
     enemies: {},
@@ -284,6 +305,26 @@ describe("http api", () => {
         code: "validation_error",
       },
     });
+
+    const duplicateSlotSave = await agent
+      .post("/player/save")
+      .set("Authorization", `Bearer ${registerPayload.data.token}`)
+      .send({
+        player: {
+          ...createStarterPlayer("hero", world),
+          ownedEquipmentIds: ["equipment-sword", "equipment-bow"],
+          equippedEquipmentIds: ["equipment-sword", "equipment-bow"],
+        },
+      })
+      .expect(400);
+
+    expect(duplicateSlotSave.body).toMatchObject({
+      success: false,
+      error: {
+        code: "validation_error",
+      },
+    });
+    expect(JSON.stringify(duplicateSlotSave.body)).toContain("same equipment slot");
   });
 
   it("normalizes a blocked saved position to the scene spawn on player load", async () => {

--- a/apps/web/src/AppController.ts
+++ b/apps/web/src/AppController.ts
@@ -14,11 +14,13 @@ import type {
 import {
   createBattle,
   ensureStoryState,
+  applyEquipmentSelection,
   getMaxHp,
   getMaxMp,
   PLAYER_AVATAR_IDS,
   performBattleAction,
   pickRandom,
+  toggleEquippedEquipmentId,
 } from "@rpg/game-core";
 import { validateAuthCredentials } from "./auth";
 import { createBattleReport, deriveOverlayMode, didSceneChange } from "./gameplay";
@@ -580,12 +582,10 @@ export class AppController {
       return;
     }
 
-    const equipped = state.player.equippedEquipmentIds.includes(equipmentId)
-      ? []
-      : [equipmentId];
+    const equipped = toggleEquippedEquipmentId(state.player, equipmentId, this.equipmentMap);
 
     this.store.setState({
-      player: this.applyEquipmentSelection(state.player, equipped),
+      player: applyEquipmentSelection(state.player, equipped, this.equipmentMap),
     });
     this.store.pushLog("장비 구성이 갱신되었습니다.");
     await this.savePlayer();
@@ -769,23 +769,4 @@ export class AppController {
     return document.activeElement;
   }
 
-  private applyEquipmentSelection(player: PlayerSave, equippedEquipmentIds: string[]): PlayerSave {
-    const previousEquipped = player.equippedEquipmentIds
-      .map((id) => this.equipmentMap[id])
-      .filter((item): item is EquipmentDefinition => Boolean(item));
-    const nextEquipped = equippedEquipmentIds
-      .map((id) => this.equipmentMap[id])
-      .filter((item): item is EquipmentDefinition => Boolean(item));
-
-    const baseAttack = player.attack - previousEquipped.reduce((total, item) => total + item.attackBonus, 0);
-    const nextAttack = baseAttack + nextEquipped.reduce((total, item) => total + item.attackBonus, 0);
-    const nextAccuracy = nextEquipped[0]?.accuracy ?? 0.8;
-
-    return {
-      ...player,
-      attack: nextAttack,
-      accuracy: nextAccuracy,
-      equippedEquipmentIds,
-    };
-  }
 }

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -592,7 +592,7 @@ button.dock-card[data-equipment] {
 
 .equipment-layout {
   display: grid;
-  grid-template-columns: minmax(210px, 0.9fr) minmax(280px, 1.45fr);
+  grid-template-columns: minmax(320px, 0.95fr) minmax(300px, 1.2fr);
   gap: 12px;
   margin-top: 14px;
 }
@@ -618,6 +618,7 @@ button.dock-card[data-equipment] {
 
 .equipment-slots {
   display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 8px;
 }
 
@@ -650,6 +651,7 @@ button.dock-card[data-equipment] {
 .equipment-slot.empty {
   cursor: default;
   opacity: 0.72;
+  border-style: dashed;
 }
 
 .equipment-slot.empty:hover {
@@ -1019,6 +1021,7 @@ button.dock-card[data-equipment] {
   .battle-actions,
   .battle-stats,
   .battle-showcase,
+  .equipment-slots,
   .meter-grid,
   .dock-grid,
   .inventory-grid {

--- a/apps/web/src/ui/actionCards.ts
+++ b/apps/web/src/ui/actionCards.ts
@@ -1,4 +1,5 @@
 import type { EquipmentDefinition, SkillDefinition } from "@rpg/game-core";
+import { EQUIPMENT_SLOT_LABELS } from "@rpg/game-core";
 
 export type ShopActionCard = {
   title: string;
@@ -20,6 +21,7 @@ export function describeEquipmentActionCard(
   options: { owned: boolean; equipped: boolean },
 ): ShopActionCard {
   const metaSegments = [
+    EQUIPMENT_SLOT_LABELS[equipment.slot],
     equipment.attackBonus !== 0 ? `공격 ${equipment.attackBonus > 0 ? `+${equipment.attackBonus}` : equipment.attackBonus}` : "",
     equipment.manaCost > 0 ? `MP ${equipment.manaCost}` : "",
     formatAccuracy(equipment.accuracy),

--- a/apps/web/src/ui/dom.ts
+++ b/apps/web/src/ui/dom.ts
@@ -6,6 +6,7 @@ import type {
   SkillDefinition,
   TacticDefinition,
 } from "@rpg/game-core";
+import { EQUIPMENT_SLOT_LABELS, EQUIPMENT_SLOT_ORDER } from "@rpg/game-core";
 import { AUTH_PASSWORD_MIN_LENGTH, AUTH_USERNAME_MAX_LENGTH, AUTH_USERNAME_MIN_LENGTH } from "../auth";
 import type { AppState } from "../state/store";
 import {
@@ -765,42 +766,51 @@ export class DomUi {
       ? equipped.map((item) => `<span class="pill">${escapeHtml(item.name)}</span>`).join("")
       : `<span class="pill muted">장착 없음</span>`;
 
-    const equippedSlots = equipped.length > 0
-      ? equipped.map((item) => `
+    const equippedBySlot = new Map(equipped.map((item) => [item.slot, item]));
+    const equippedSlots = EQUIPMENT_SLOT_ORDER.map((slot) => {
+      const item = equippedBySlot.get(slot);
+      const slotLabel = EQUIPMENT_SLOT_LABELS[slot];
+      if (!item) {
+        return `
+          <div class="equipment-slot empty" data-equipment-slot="${escapeHtml(slot)}">
+            <span class="inventory-icon empty"></span>
+            <span class="inventory-copy">
+              <strong>${escapeHtml(slotLabel)}</strong>
+              <span>비어 있음</span>
+            </span>
+          </div>
+        `;
+      }
+
+      return `
         <button
           class="equipment-slot"
           type="button"
           data-inventory-equipment="${escapeHtml(item.id)}"
-          title="${escapeHtml(`${item.name} 장착 해제`)}"
+          data-equipment-slot="${escapeHtml(slot)}"
+          title="${escapeHtml(`${slotLabel}: ${item.name} 장착 해제`)}"
           aria-pressed="true"
         >
           <span class="inventory-icon">
             <img src="${escapeHtml(item.texturePath)}" alt="" loading="lazy">
           </span>
           <span class="inventory-copy">
-            <strong>${escapeHtml(item.name)}</strong>
-            <span>공격 +${item.attackBonus} · 명중 ${Math.round(item.accuracy * 100)}%</span>
+            <strong>${escapeHtml(slotLabel)}</strong>
+            <span>${escapeHtml(item.name)} · 공격 +${item.attackBonus} · 명중 ${Math.round(item.accuracy * 100)}%</span>
           </span>
         </button>
-      `).join("")
-      : `
-        <div class="equipment-slot empty">
-          <span class="inventory-icon empty"></span>
-          <span class="inventory-copy">
-            <strong>비어 있음</strong>
-            <span>착용한 장비가 없습니다.</span>
-          </span>
-        </div>
       `;
+    }).join("");
     const inventoryItems = ownedEquipment.length > 0
       ? ownedEquipment.map((item) => {
         const equippedState = player.equippedEquipmentIds.includes(item.id);
+        const slotLabel = EQUIPMENT_SLOT_LABELS[item.slot];
         return `
           <button
             class="inventory-item ${equippedState ? "equipped" : ""}"
             type="button"
             data-inventory-equipment="${escapeHtml(item.id)}"
-            title="${escapeHtml(`${item.name} 장착/해제`)}"
+            title="${escapeHtml(`${slotLabel}: ${item.name}`)}"
             aria-pressed="${String(equippedState)}"
           >
             <span class="inventory-icon">
@@ -808,7 +818,7 @@ export class DomUi {
             </span>
             <span class="inventory-copy">
               <strong>${escapeHtml(item.name)}</strong>
-              <span>공격 +${item.attackBonus} · 명중 ${Math.round(item.accuracy * 100)}%</span>
+              <span>${escapeHtml(slotLabel)} · 공격 +${item.attackBonus} · 명중 ${Math.round(item.accuracy * 100)}%</span>
             </span>
             ${equippedState ? `<span class="inventory-badge">E</span>` : ""}
           </button>
@@ -833,7 +843,7 @@ export class DomUi {
           <section class="equipment-board" aria-label="장비창">
             <div class="inventory-section-heading">
               <h3>장비</h3>
-              <span class="pill">${equipped.length} / 1</span>
+              <span class="pill">${equipped.length} / ${EQUIPMENT_SLOT_ORDER.length}</span>
             </div>
             <div class="equipment-slots">
               ${equippedSlots}

--- a/apps/web/test/actionCards.test.ts
+++ b/apps/web/test/actionCards.test.ts
@@ -4,6 +4,8 @@ import { describeEquipmentActionCard, describeSkillActionCard } from "../src/ui/
 
 const equipment: EquipmentDefinition = {
   id: "equipment-bronze-sword",
+  itemType: "equipment",
+  slot: "weapon",
   name: "청동 검",
   texturePath: "/assets/generated/items/item-village-sword.png",
   village: "시작의 마을",
@@ -31,6 +33,7 @@ describe("shop action card helpers", () => {
     const card = describeEquipmentActionCard(equipment, { owned: false, equipped: false });
 
     expect(card.description).toBe(equipment.description);
+    expect(card.meta).toContain("무기");
     expect(card.meta).toContain("공격 +7");
     expect(card.meta).toContain("명중 92%");
     expect(card.action).toBe("120 코인 구매");

--- a/packages/game-core/src/content/equipmentTextures.ts
+++ b/packages/game-core/src/content/equipmentTextures.ts
@@ -1,3 +1,5 @@
+import type { EquipmentSlot } from "../types";
+
 const GENERATED_ITEM_ROOT = "/assets/generated/items";
 
 export const EQUIPMENT_TEXTURE_IDS = [
@@ -78,8 +80,47 @@ const EQUIPMENT_NAME_TO_TEXTURE_ID: Record<string, EquipmentTextureId> = {
   "우주의 중력석 반지": "cosmic-gravity-ring",
 };
 
+const EQUIPMENT_TEXTURE_ID_TO_SLOT: Record<EquipmentTextureId, EquipmentSlot> = {
+  "village-sword": "weapon",
+  "healing-sword": "weapon",
+  "wooden-hammer": "weapon",
+  "wooden-shield": "hands",
+  "simple-bow": "weapon",
+  "heavy-axe": "weapon",
+  "iron-armor": "armor",
+  "desert-longsword": "weapon",
+  "sand-hat": "head",
+  "sunlight-hat": "head",
+  "mountain-spear": "weapon",
+  "stone-gauntlet": "hands",
+  "bamboo-spear": "weapon",
+  "crocodile-tooth-spear": "weapon",
+  "water-droplet-sword": "weapon",
+  "river-sword": "weapon",
+  "deep-sea-predator-blade": "weapon",
+  "kraken-tentacle-whip": "weapon",
+  "sky-sword": "weapon",
+  "light-sword": "weapon",
+  "grassland-dagger": "weapon",
+  "peace-guard-ring": "accessory",
+  "neighbor-longbow": "weapon",
+  "desert-sabre": "weapon",
+  "sand-buckler": "hands",
+  "mountain-battle-axe": "weapon",
+  "snow-marching-boots": "feet",
+  "swamp-thorn-spear": "weapon",
+  "upstream-whirlpool-amulet": "accessory",
+  "deep-sea-shell-armor": "armor",
+  "sky-lightning-spear": "weapon",
+  "cosmic-gravity-ring": "accessory",
+};
+
 export function getEquipmentTextureId(name: string): EquipmentTextureId {
   return EQUIPMENT_NAME_TO_TEXTURE_ID[name] ?? DEFAULT_EQUIPMENT_TEXTURE_ID;
+}
+
+export function getEquipmentSlot(name: string): EquipmentSlot {
+  return EQUIPMENT_TEXTURE_ID_TO_SLOT[getEquipmentTextureId(name)] ?? "weapon";
 }
 
 export function getEquipmentTexturePath(name: string): string {

--- a/packages/game-core/src/content/legacy.ts
+++ b/packages/game-core/src/content/legacy.ts
@@ -21,7 +21,7 @@ import {
   getSceneThemeId,
 } from "./sceneMetadata";
 import { getEnemyTexturePath } from "./enemyTextures";
-import { getEquipmentTexturePath } from "./equipmentTextures";
+import { getEquipmentSlot, getEquipmentTexturePath } from "./equipmentTextures";
 import { toLocationKey, toStableId } from "../utils/id";
 import { assertValidWorldContent } from "../validation";
 
@@ -454,6 +454,8 @@ export function buildWorldContentFromLegacy(input: {
   const equipment: EquipmentDefinition[] = input.equipment.map((item) => ({
     id: toStableId("equipment", item.이름),
     name: item.이름,
+    itemType: "equipment",
+    slot: getEquipmentSlot(String(Object.values(item)[0] ?? "")),
     texturePath: getEquipmentTexturePath(item["이름"]),
     village: item.판매마을,
     cost: item.cost,

--- a/packages/game-core/src/engine/equipment.ts
+++ b/packages/game-core/src/engine/equipment.ts
@@ -1,0 +1,95 @@
+import type { EquipmentDefinition, EquipmentSlot, PlayerSave } from "../types";
+
+export const EQUIPMENT_SLOT_ORDER: EquipmentSlot[] = ["weapon", "armor", "head", "hands", "feet", "accessory"];
+
+export const EQUIPMENT_SLOT_LABELS: Record<EquipmentSlot, string> = {
+  weapon: "무기",
+  armor: "방어구",
+  head: "머리",
+  hands: "손",
+  feet: "발",
+  accessory: "장신구",
+};
+
+export function getEquippedEquipment(
+  equippedEquipmentIds: string[],
+  equipmentById: Record<string, EquipmentDefinition>,
+): EquipmentDefinition[] {
+  return equippedEquipmentIds
+    .map((id) => equipmentById[id])
+    .filter((item): item is EquipmentDefinition => Boolean(item));
+}
+
+export function normalizeEquippedEquipmentIds(
+  equippedEquipmentIds: string[],
+  equipmentById: Record<string, EquipmentDefinition>,
+): string[] {
+  const usedSlots = new Set<EquipmentSlot>();
+  const normalized: string[] = [];
+
+  equippedEquipmentIds.forEach((id) => {
+    const item = equipmentById[id];
+    if (!item || usedSlots.has(item.slot)) {
+      return;
+    }
+
+    usedSlots.add(item.slot);
+    normalized.push(id);
+  });
+
+  return normalized;
+}
+
+export function toggleEquippedEquipmentId(
+  player: PlayerSave,
+  equipmentId: string,
+  equipmentById: Record<string, EquipmentDefinition>,
+): string[] {
+  const item = equipmentById[equipmentId];
+  if (!item || !player.ownedEquipmentIds.includes(equipmentId)) {
+    return normalizeEquippedEquipmentIds(player.equippedEquipmentIds, equipmentById);
+  }
+
+  if (player.equippedEquipmentIds.includes(equipmentId)) {
+    return player.equippedEquipmentIds.filter((id) => id !== equipmentId);
+  }
+
+  return normalizeEquippedEquipmentIds(
+    [
+      ...player.equippedEquipmentIds.filter((id) => equipmentById[id]?.slot !== item.slot),
+      equipmentId,
+    ],
+    equipmentById,
+  );
+}
+
+export function sumEquipmentAttackBonus(
+  equippedEquipmentIds: string[],
+  equipmentById: Record<string, EquipmentDefinition>,
+): number {
+  return getEquippedEquipment(equippedEquipmentIds, equipmentById).reduce((total, item) => total + item.attackBonus, 0);
+}
+
+export function selectEquipmentAccuracy(
+  equippedEquipmentIds: string[],
+  equipmentById: Record<string, EquipmentDefinition>,
+): number {
+  const equipped = getEquippedEquipment(equippedEquipmentIds, equipmentById);
+  return equipped.find((item) => item.slot === "weapon")?.accuracy ?? equipped[0]?.accuracy ?? 0.8;
+}
+
+export function applyEquipmentSelection(
+  player: PlayerSave,
+  equippedEquipmentIds: string[],
+  equipmentById: Record<string, EquipmentDefinition>,
+): PlayerSave {
+  const normalizedEquippedIds = normalizeEquippedEquipmentIds(equippedEquipmentIds, equipmentById);
+  const baseAttack = player.attack - sumEquipmentAttackBonus(player.equippedEquipmentIds, equipmentById);
+
+  return {
+    ...player,
+    attack: baseAttack + sumEquipmentAttackBonus(normalizedEquippedIds, equipmentById),
+    accuracy: selectEquipmentAccuracy(normalizedEquippedIds, equipmentById),
+    equippedEquipmentIds: normalizedEquippedIds,
+  };
+}

--- a/packages/game-core/src/index.ts
+++ b/packages/game-core/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./types";
 export * from "./utils/id";
 export * from "./engine/player";
+export * from "./engine/equipment";
 export * from "./engine/battle";
 export * from "./content/legacy";
 export * from "./content/sceneMetadata";

--- a/packages/game-core/src/types.ts
+++ b/packages/game-core/src/types.ts
@@ -53,9 +53,13 @@ export type SkillDefinition = {
   effects: EffectDefinition[];
 };
 
+export type EquipmentSlot = "weapon" | "armor" | "head" | "hands" | "feet" | "accessory";
+
 export type EquipmentDefinition = {
   id: string;
   name: string;
+  itemType: "equipment";
+  slot: EquipmentSlot;
   texturePath: string;
   village?: string;
   cost: number;

--- a/packages/game-core/src/validation.ts
+++ b/packages/game-core/src/validation.ts
@@ -20,6 +20,7 @@ import {
 } from "./content/sceneMetadata";
 import { getEnemyTexturePaths } from "./content/enemyTextures";
 import { getEquipmentTexturePaths } from "./content/equipmentTextures";
+import { EQUIPMENT_SLOT_ORDER } from "./engine/equipment";
 
 export type ValidationIssue = {
   path: string;
@@ -35,6 +36,7 @@ const VALID_SCENE_THEMES = new Set(SCENE_THEME_IDS);
 const VALID_COMMON_SCENE_TEXTURES = new Set(getCommonSceneTexturePaths());
 const VALID_ENEMY_TEXTURES = new Set(getEnemyTexturePaths());
 const VALID_EQUIPMENT_TEXTURES = new Set(getEquipmentTexturePaths());
+const VALID_EQUIPMENT_SLOTS = new Set(EQUIPMENT_SLOT_ORDER);
 
 function issue(path: string, message: string): ValidationIssue {
   return { path, message };
@@ -153,6 +155,14 @@ function validateEquipment(equipment: EquipmentDefinition, path: string): Valida
 
   if (!equipment.name) {
     issues.push(issue(`${path}.name`, "Equipment name is required."));
+  }
+
+  if (equipment.itemType !== "equipment") {
+    issues.push(issue(`${path}.itemType`, "Equipment itemType must be equipment."));
+  }
+
+  if (!VALID_EQUIPMENT_SLOTS.has(equipment.slot)) {
+    issues.push(issue(`${path}.slot`, "Equipment slot is not supported."));
   }
 
   if (!VALID_EQUIPMENT_TEXTURES.has(equipment.texturePath)) {

--- a/packages/game-core/test/battle.test.ts
+++ b/packages/game-core/test/battle.test.ts
@@ -102,6 +102,8 @@ function makeEquipment(id: string, effect: EffectDefinition) {
   return {
     id,
     name: id,
+    itemType: "equipment" as const,
+    slot: "accessory" as const,
     texturePath: TEST_EQUIPMENT_TEXTURE,
     cost: 0,
     attackBonus: 0,

--- a/packages/game-core/test/content.test.ts
+++ b/packages/game-core/test/content.test.ts
@@ -34,6 +34,7 @@ describe("legacy content conversion", () => {
     expect(Object.keys(world.locations).length).toBeGreaterThan(10);
     expect(world.skills.every((entry) => entry.effects.length > 0)).toBe(true);
     expect(world.equipment.every((entry) => entry.effects.length >= 0)).toBe(true);
+    expect(world.equipment.every((entry) => entry.itemType === "equipment" && Boolean(entry.slot))).toBe(true);
     expect(Object.values(world.locations).every((location) => location.scene.assets.mapJsonPath.endsWith(".json"))).toBe(true);
     expect(Object.values(world.locations).every((location) => location.scene.collisionZones.length > 0)).toBe(true);
     expect(validateWorldContent(world)).toEqual([]);

--- a/packages/game-core/test/equipment.test.ts
+++ b/packages/game-core/test/equipment.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyEquipmentSelection,
+  normalizeEquippedEquipmentIds,
+  toggleEquippedEquipmentId,
+  type EquipmentDefinition,
+  type PlayerSave,
+} from "../src";
+
+const equipmentById: Record<string, EquipmentDefinition> = {
+  "equipment-sword": makeEquipment("equipment-sword", "weapon", 5, 0.9),
+  "equipment-bow": makeEquipment("equipment-bow", "weapon", 8, 0.75),
+  "equipment-armor": makeEquipment("equipment-armor", "armor", 2, 0.8),
+};
+
+function makeEquipment(
+  id: string,
+  slot: EquipmentDefinition["slot"],
+  attackBonus: number,
+  accuracy: number,
+): EquipmentDefinition {
+  return {
+    id,
+    itemType: "equipment",
+    slot,
+    name: id,
+    texturePath: "/assets/generated/items/item-village-sword.png",
+    cost: 0,
+    attackBonus,
+    manaCost: 0,
+    accuracy,
+    description: id,
+    effects: [],
+  };
+}
+
+function makePlayer(overrides: Partial<PlayerSave> = {}): PlayerSave {
+  return {
+    version: 2,
+    username: "tester",
+    coins: 0,
+    experience: 0,
+    level: 1,
+    currentHp: 100,
+    currentMp: 50,
+    attack: 10,
+    defense: 0,
+    speed: 10,
+    accuracy: 0.8,
+    locationKey: "start",
+    position: { x: 0, y: 0 },
+    facing: "down",
+    visitedMainLocations: [],
+    visitedLocationKeys: [],
+    storyState: {},
+    ownedEquipmentIds: Object.keys(equipmentById),
+    equippedEquipmentIds: [],
+    learnedSkillIds: [],
+    learnedTacticIds: [],
+    questCompletion: {},
+    flags: {
+      demonLordDefeated: false,
+    },
+    ...overrides,
+  };
+}
+
+describe("equipment slots", () => {
+  it("replaces equipment in the same slot while preserving other slots", () => {
+    let player = makePlayer();
+
+    player = applyEquipmentSelection(player, toggleEquippedEquipmentId(player, "equipment-sword", equipmentById), equipmentById);
+    expect(player.equippedEquipmentIds).toEqual(["equipment-sword"]);
+    expect(player.attack).toBe(15);
+    expect(player.accuracy).toBe(0.9);
+
+    player = applyEquipmentSelection(player, toggleEquippedEquipmentId(player, "equipment-armor", equipmentById), equipmentById);
+    expect(player.equippedEquipmentIds).toEqual(["equipment-sword", "equipment-armor"]);
+    expect(player.attack).toBe(17);
+    expect(player.accuracy).toBe(0.9);
+
+    player = applyEquipmentSelection(player, toggleEquippedEquipmentId(player, "equipment-bow", equipmentById), equipmentById);
+    expect(player.equippedEquipmentIds).toEqual(["equipment-armor", "equipment-bow"]);
+    expect(player.attack).toBe(20);
+    expect(player.accuracy).toBe(0.75);
+  });
+
+  it("normalizes duplicate slots by keeping the first item in that slot", () => {
+    expect(normalizeEquippedEquipmentIds(["equipment-sword", "equipment-bow", "equipment-armor"], equipmentById)).toEqual([
+      "equipment-sword",
+      "equipment-armor",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add shared equipment slots, labels, and equip/stat helpers in game-core
- enforce owned equipment and one-item-per-slot saves on the server
- render a six-slot equipment board and inventory slot labels, with double-click equip/replacement behavior

## Verification
- corepack pnpm -r typecheck
- corepack pnpm -r lint
- corepack pnpm -r test
- corepack pnpm -r build
- git diff --check
- Chrome smoke against local dev servers: 6 slots rendered, inventory item equipped, same-slot weapon replacement kept one equipped badge