### PR TITLE
Move persistent UI outside the gameplay viewport

### DIFF
--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -47,7 +47,12 @@ button {
 .viewport-shell {
   position: relative;
   min-height: 100vh;
-  overflow: hidden;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: 12px;
+  padding: 14px;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .atmosphere {
@@ -76,17 +81,102 @@ button {
   background: rgba(208, 124, 71, 0.22);
 }
 
+.status-bar {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  padding: 12px 14px;
+  border-radius: 18px;
+  background: rgba(10, 18, 15, 0.9);
+  border: 1px solid var(--line-soft);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.28);
+  backdrop-filter: blur(18px);
+}
+
+.game-layout {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) minmax(520px, 1fr) minmax(280px, 360px);
+  gap: 12px;
+  min-height: calc(100vh - 112px);
+}
+
+.left-ui-shell {
+  min-width: 0;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: 64px minmax(0, 1fr);
+  gap: 10px;
+}
+
+.side-menu {
+  align-self: stretch;
+  display: grid;
+  align-content: start;
+  gap: 8px;
+  padding: 8px;
+  border-radius: 18px;
+  background: rgba(10, 18, 15, 0.76);
+  border: 1px solid var(--line-soft);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.2);
+  backdrop-filter: blur(16px);
+}
+
+.side-tab {
+  min-height: 52px;
+  border: 0;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.07);
+  color: var(--text-muted);
+  font-weight: 700;
+  transition: background 180ms ease, color 180ms ease, opacity 180ms ease;
+}
+
+.side-tab.active {
+  background: rgba(83, 181, 156, 0.2);
+  color: var(--text-main);
+}
+
+.side-tab:disabled {
+  cursor: not-allowed;
+  opacity: 0.38;
+}
+
+.left-panel-stack,
+.right-ui-shell {
+  min-width: 0;
+  min-height: 0;
+}
+
+.right-ui-shell {
+  display: grid;
+}
+
+.left-panel-stack > .panel {
+  display: none;
+  height: 100%;
+  min-height: 0;
+  padding: 14px;
+  overflow: hidden;
+}
+
+.left-panel-stack > .panel.visible.menu-open {
+  display: block;
+}
+
 .game-stage {
   position: relative;
-  min-height: 100vh;
-  padding: 18px;
+  min-width: 0;
+  min-height: 0;
+  height: 100%;
 }
 
 .stage-canvas,
 .ui-layer {
   position: absolute;
-  inset: 18px;
-  border-radius: 32px;
+  inset: 0;
+  border-radius: 22px;
 }
 
 .stage-canvas {
@@ -110,12 +200,13 @@ button {
   pointer-events: none;
 }
 
-.ui-layer > * {
+.ui-layer > .dialogue-panel,
+.ui-layer > .auth-panel {
   pointer-events: auto;
 }
 
 .panel {
-  border-radius: 24px;
+  border-radius: 18px;
   background: var(--surface);
   border: 1px solid var(--line-soft);
   box-shadow: 0 18px 40px rgba(0, 0, 0, 0.24);
@@ -125,6 +216,12 @@ button {
 .panel-shell {
   display: grid;
   gap: 14px;
+}
+
+.left-panel-stack .panel-shell,
+.right-ui-shell .panel-shell {
+  height: 100%;
+  grid-template-rows: auto minmax(0, 1fr);
 }
 
 .panel-shell-header {
@@ -167,6 +264,13 @@ button {
   min-width: 0;
 }
 
+.left-panel-stack .panel-shell-body,
+.right-ui-shell .panel-shell-body {
+  min-height: 0;
+  overflow: auto;
+  padding-right: 2px;
+}
+
 .panel.is-collapsed .panel-shell {
   gap: 0;
 }
@@ -183,46 +287,40 @@ button {
   position: absolute;
 }
 
+.status-bar.layout-panel {
+  position: sticky;
+}
+
+.left-panel-stack > .layout-panel,
+.right-ui-shell > .layout-panel {
+  position: static;
+}
+
 .layout-panel.is-dragging {
   user-select: none;
 }
 
 .hud-panel {
-  position: absolute;
-  top: 18px;
-  left: 18px;
-  right: 18px;
-  padding: 16px 18px;
+  display: block;
 }
 
 .log-panel {
-  position: absolute;
-  top: 154px;
-  right: 18px;
-  width: 320px;
-  padding: 16px;
+  display: none;
 }
 
 .chat-panel {
-  position: absolute;
-  right: 18px;
-  bottom: 168px;
-  width: 340px;
-  padding: 16px;
+  display: block;
+  height: 100%;
+  min-height: 0;
+  padding: 14px;
+  overflow: hidden;
 }
 
 .action-panel {
   display: none;
-  position: absolute;
-  left: 18px;
-  right: 376px;
-  bottom: 18px;
-  padding: 16px 18px;
 }
 
-.action-panel.visible,
 .dialogue-panel.visible,
-.battle-panel.visible,
 .auth-panel.visible {
   display: block;
 }
@@ -230,21 +328,15 @@ button {
 .dialogue-panel {
   display: none;
   position: absolute;
-  left: 18px;
-  bottom: 178px;
-  width: min(540px, calc(100% - 412px));
-  padding: 18px;
+  left: 50%;
+  bottom: 20px;
+  width: min(680px, calc(100% - 32px));
+  padding: 16px;
+  transform: translateX(-50%);
 }
 
 .battle-panel {
   display: none;
-  position: absolute;
-  left: 18px;
-  bottom: 178px;
-  width: min(540px, calc(100% - 412px));
-  max-height: 58vh;
-  overflow: auto;
-  padding: 18px;
 }
 
 .auth-panel {
@@ -310,11 +402,75 @@ button {
   gap: 10px;
 }
 
-.layout-actions {
+.status-bar-inner {
+  display: grid;
+  grid-template-columns: minmax(180px, 260px) minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+}
+
+.status-location {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.status-location strong {
+  overflow: hidden;
+  font-size: 1.06rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.status-location span {
+  color: var(--text-muted);
+  font-size: 0.86rem;
+}
+
+.status-meters {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: repeat(7, minmax(68px, 1fr));
+  gap: 8px;
+}
+
+.status-actions {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 8px;
   flex-wrap: wrap;
+}
+
+.action-prompt {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 14px;
+  margin-top: 10px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.action-prompt.accent {
+  background: rgba(83, 181, 156, 0.12);
+}
+
+.action-prompt.danger {
+  background: rgba(216, 109, 96, 0.12);
+}
+
+.action-prompt h3 {
+  margin: 4px 0 0;
+  font-size: 0.98rem;
+}
+
+.action-prompt p {
+  margin: 6px 0 0;
+  color: var(--text-muted);
+  line-height: 1.45;
 }
 
 .status-pill,
@@ -358,43 +514,6 @@ button {
   background: rgba(255, 255, 255, 0.05);
 }
 
-.meter-grid {
-  display: grid;
-  grid-template-columns: repeat(6, minmax(0, 1fr));
-  gap: 10px;
-  margin-top: 16px;
-}
-
-.context-card {
-  display: flex;
-  align-items: start;
-  justify-content: space-between;
-  gap: 14px;
-  margin-top: 14px;
-  padding: 14px 16px;
-  border-radius: 22px;
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-}
-
-.context-card.accent {
-  background: rgba(83, 181, 156, 0.12);
-}
-
-.context-card.danger {
-  background: rgba(216, 109, 96, 0.12);
-}
-
-.context-card h3 {
-  margin: 6px 0 0;
-}
-
-.context-card p {
-  margin: 8px 0 0;
-  color: var(--text-muted);
-  line-height: 1.5;
-}
-
 .meter-card,
 .battle-stats div {
   padding: 12px 14px;
@@ -415,6 +534,15 @@ button {
   display: block;
   margin-top: 4px;
   font-size: 1.05rem;
+}
+
+.status-meters .meter-card {
+  padding: 8px 10px;
+  border-radius: 12px;
+}
+
+.status-meters .meter-card strong {
+  font-size: 0.98rem;
 }
 
 .segmented {
@@ -585,14 +713,14 @@ button.dock-card[data-equipment] {
 }
 
 .action-panel .panel-shell-body {
-  max-height: min(52vh, 560px);
+  max-height: none;
   overflow: auto;
   padding-right: 2px;
 }
 
 .equipment-layout {
   display: grid;
-  grid-template-columns: minmax(320px, 0.95fr) minmax(300px, 1.2fr);
+  grid-template-columns: 1fr;
   gap: 12px;
   margin-top: 14px;
 }
@@ -743,7 +871,7 @@ button.dock-card[data-equipment] {
 
 .battle-showcase {
   display: grid;
-  grid-template-columns: 156px minmax(0, 1fr);
+  grid-template-columns: 1fr;
   gap: 12px;
   align-items: stretch;
   margin: 14px 0;
@@ -753,7 +881,7 @@ button.dock-card[data-equipment] {
   position: relative;
   display: grid;
   place-items: center;
-  min-height: 156px;
+  min-height: 180px;
   aspect-ratio: 1;
   overflow: hidden;
   border-radius: 18px;
@@ -864,6 +992,23 @@ button.dock-card[data-equipment] {
   margin: 14px 0;
 }
 
+.chat-panel .panel-shell-body {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  gap: 10px;
+}
+
+.chat-panel .chat-list {
+  min-height: 0;
+  overflow: auto;
+  margin: 0;
+}
+
+.log-panel .log-list {
+  max-height: none;
+  overflow: auto;
+}
+
 .chat-item,
 .log-item {
   padding: 10px 12px;
@@ -888,96 +1033,56 @@ button.dock-card[data-equipment] {
   gap: 8px;
 }
 
-@media (min-width: 921px) {
-  .layout-panel.floating-enabled {
-    min-width: var(--panel-min-width, 280px);
-    min-height: var(--panel-min-height, 160px);
-    overflow: auto;
-    overscroll-behavior: contain;
-    resize: both;
-    cursor: grab;
-  }
-
-  .layout-panel.floating-enabled.is-dragging {
-    cursor: grabbing;
-  }
-
-  .layout-panel.floating-enabled button,
-  .layout-panel.floating-enabled [role="button"] {
-    cursor: pointer;
-  }
-
-  .layout-panel.floating-enabled input,
-  .layout-panel.floating-enabled textarea {
-    cursor: text;
-  }
-
-  .layout-panel.floating-enabled.is-collapsed {
-    height: auto !important;
-    min-height: 0 !important;
-    overflow: hidden;
-    resize: none;
-  }
-}
-
 @media (max-width: 1180px) {
-  .hud-panel {
-    right: 16px;
+  .game-layout {
+    grid-template-columns: minmax(240px, 300px) minmax(420px, 1fr) minmax(240px, 300px);
   }
 
-  .log-panel {
-    width: 280px;
+  .status-bar-inner {
+    grid-template-columns: 1fr;
+    align-items: start;
   }
 
-  .chat-panel {
-    width: 300px;
+  .status-actions {
+    justify-content: flex-start;
   }
 
-  .action-panel,
-  .dialogue-panel,
-  .battle-panel {
-    right: 332px;
-    width: auto;
-  }
-
-  .meter-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+  .status-meters {
+    grid-template-columns: repeat(4, minmax(68px, 1fr));
   }
 }
 
 @media (max-width: 920px) {
-  .game-stage {
-    padding: 12px;
+  .viewport-shell {
+    padding: 10px;
+    overflow-y: auto;
   }
 
-  .stage-canvas,
-  .ui-layer {
-    inset: 12px;
-    border-radius: 24px;
+  .game-layout {
+    grid-template-columns: 1fr;
+    min-height: auto;
   }
 
-  .hud-panel,
-  .log-panel,
-  .chat-panel,
-  .action-panel,
-  .dialogue-panel,
-  .battle-panel {
-    position: static;
-    width: auto;
-    margin-top: 12px;
-  }
-
-  .ui-layer {
+  .left-ui-shell {
     display: grid;
     grid-template-columns: 1fr;
-    align-content: start;
-    gap: 12px;
-    padding: 12px;
-    overflow: auto;
   }
 
-  .stage-canvas {
+  .side-menu {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .left-panel-stack > .panel {
+    height: auto;
+    max-height: 42vh;
+  }
+
+  .game-stage {
     min-height: 58vh;
+  }
+
+  .right-ui-shell {
+    min-height: 280px;
   }
 
   .auth-panel {
@@ -986,19 +1091,9 @@ button.dock-card[data-equipment] {
   }
 
   .battle-stats,
-  .meter-grid,
+  .status-meters,
   .dock-grid {
     grid-template-columns: 1fr 1fr;
-  }
-
-  .action-panel .panel-shell-body {
-    max-height: none;
-    overflow: visible;
-    padding-right: 0;
-  }
-
-  .equipment-layout {
-    grid-template-columns: 1fr;
   }
 }
 
@@ -1008,10 +1103,15 @@ button.dock-card[data-equipment] {
   .dock-header,
   .panel-header,
   .chat-form,
-  .dialogue-footer,
-  .context-card {
+  .dialogue-footer {
     grid-template-columns: 1fr;
     display: grid;
+  }
+
+  .status-meters,
+  .action-prompt {
+    display: grid;
+    grid-template-columns: 1fr;
   }
 
   .panel-shell-controls {
@@ -1022,7 +1122,6 @@ button.dock-card[data-equipment] {
   .battle-stats,
   .battle-showcase,
   .equipment-slots,
-  .meter-grid,
   .dock-grid,
   .inventory-grid {
     grid-template-columns: 1fr;

--- a/apps/web/src/ui/dom.ts
+++ b/apps/web/src/ui/dom.ts
@@ -15,7 +15,6 @@ import {
   cloneCollapsedPanels,
   FLOATING_LAYOUT_STORAGE_KEY,
   FLOATING_PANEL_CONSTRAINTS,
-  isFloatingLayoutEnabled,
   sanitizeStoredPanelPreferences,
   type FloatingPanelCollapsedState,
   type FloatingPanelKey,
@@ -50,6 +49,10 @@ type LayoutGesture =
     mode: "resize";
   };
 
+type SidePanelKey = Extract<FloatingPanelKey, "action" | "battle" | "log">;
+
+const SIDE_PANEL_KEYS: SidePanelKey[] = ["action", "battle", "log"];
+
 function escapeHtml(value: unknown): string {
   return String(value)
     .replaceAll("&", "&amp;")
@@ -70,7 +73,11 @@ export class DomUi {
   private readonly battlePanel: HTMLElement;
   private readonly chatPanel: HTMLElement;
   private readonly logPanel: HTMLElement;
+  private readonly sideMenuButtons: NodeListOf<HTMLButtonElement>;
   private readonly floatingPanels: Record<FloatingPanelKey, HTMLElement>;
+  private activeSidePanel: SidePanelKey = "action";
+  private actionPanelWasVisible = false;
+  private battlePanelWasVisible = false;
   private panelLayouts: Partial<Record<FloatingPanelKey, FloatingPanelLayout>> = {};
   private savedPanelLayouts: Partial<Record<FloatingPanelKey, FloatingPanelLayout>> = {};
   private collapsedPanels: FloatingPanelCollapsedState = {};
@@ -89,18 +96,31 @@ export class DomUi {
       <div class="viewport-shell">
         <div class="atmosphere atmosphere-one"></div>
         <div class="atmosphere atmosphere-two"></div>
-        <main class="game-stage">
-          <div class="stage-canvas"></div>
-          <div class="ui-layer">
-            <header class="panel hud-panel"></header>
-            <aside class="panel log-panel"></aside>
+        <header class="status-bar hud-panel"></header>
+        <div class="game-layout">
+          <aside class="left-ui-shell" aria-label="게임 메뉴">
+            <nav class="side-menu" data-no-panel-drag>
+              <button class="side-tab active" type="button" data-side-panel="action" aria-controls="action-panel" aria-expanded="true">행동</button>
+              <button class="side-tab" type="button" data-side-panel="battle" aria-controls="battle-panel" aria-expanded="false">전투</button>
+              <button class="side-tab" type="button" data-side-panel="log" aria-controls="log-panel" aria-expanded="false">로그</button>
+            </nav>
+            <div class="left-panel-stack">
+              <section id="action-panel" class="panel action-panel"></section>
+              <section id="battle-panel" class="panel battle-panel"></section>
+              <aside id="log-panel" class="panel log-panel"></aside>
+            </div>
+          </aside>
+          <main class="game-stage">
+            <div class="stage-canvas"></div>
+            <div class="ui-layer">
+              <section class="panel dialogue-panel"></section>
+              <section class="panel auth-panel"></section>
+            </div>
+          </main>
+          <aside class="right-ui-shell" aria-label="채팅">
             <aside class="panel chat-panel"></aside>
-            <section class="panel action-panel"></section>
-            <section class="panel dialogue-panel"></section>
-            <section class="panel battle-panel"></section>
-            <section class="panel auth-panel"></section>
-          </div>
-        </main>
+          </aside>
+        </div>
       </div>
     `;
 
@@ -113,6 +133,7 @@ export class DomUi {
     this.battlePanel = this.root.querySelector(".battle-panel") as HTMLElement;
     this.chatPanel = this.root.querySelector(".chat-panel") as HTMLElement;
     this.logPanel = this.root.querySelector(".log-panel") as HTMLElement;
+    this.sideMenuButtons = this.root.querySelectorAll<HTMLButtonElement>("[data-side-panel]");
     this.floatingPanels = {
       hud: this.hudPanel,
       log: this.logPanel,
@@ -129,6 +150,7 @@ export class DomUi {
     this.collapsedPanels = cloneCollapsedPanels(storedPreferences.collapsed);
     this.nextPanelZ = this.computeNextPanelZ();
     this.initializeFloatingPanels();
+    this.bindSideMenu();
   }
 
   getGameContainer(): HTMLElement {
@@ -198,7 +220,48 @@ export class DomUi {
   }
 
   private isFloatingLayoutActive(): boolean {
-    return typeof window !== "undefined" && isFloatingLayoutEnabled(window.innerWidth);
+    return false;
+  }
+
+  private isSidePanelKey(value: string | undefined): value is SidePanelKey {
+    return value === "action" || value === "battle" || value === "log";
+  }
+
+  private bindSideMenu(): void {
+    this.sideMenuButtons.forEach((button) => {
+      const key = button.dataset.sidePanel;
+      if (!this.isSidePanelKey(key)) {
+        return;
+      }
+
+      button.onclick = () => {
+        this.activeSidePanel = key;
+        this.syncSidePanels();
+      };
+    });
+    this.syncSidePanels();
+  }
+
+  private syncSidePanels(): void {
+    const availablePanels = SIDE_PANEL_KEYS.filter((key) => this.floatingPanels[key].classList.contains("visible"));
+    if (availablePanels.length > 0 && !availablePanels.includes(this.activeSidePanel)) {
+      this.activeSidePanel = availablePanels[0] ?? this.activeSidePanel;
+    }
+
+    SIDE_PANEL_KEYS.forEach((key) => {
+      const panel = this.floatingPanels[key];
+      const isAvailable = panel.classList.contains("visible");
+      const isActive = isAvailable && key === this.activeSidePanel;
+      panel.classList.toggle("menu-open", isActive);
+
+      const button = Array.from(this.sideMenuButtons).find((entry) => entry.dataset.sidePanel === key);
+      if (!button) {
+        return;
+      }
+      button.disabled = !isAvailable;
+      button.classList.toggle("active", isActive);
+      button.setAttribute("aria-expanded", String(isActive));
+    });
   }
 
   private measurePanelLayout(key: FloatingPanelKey): FloatingPanelLayout | null {
@@ -528,11 +591,13 @@ export class DomUi {
     controls?: string;
     body: string;
     bodyClassName?: string;
+    collapsible?: boolean;
   }): string {
     const headingTag = options.titleTag ?? "h2";
     const eyebrow = escapeHtml(options.eyebrow);
     const title = escapeHtml(options.title);
     const subtitle = options.subtitle ? escapeHtml(options.subtitle) : "";
+    const collapsible = options.collapsible ?? true;
 
     return `
       <div class="panel-shell">
@@ -546,14 +611,14 @@ export class DomUi {
           </div>
           <div class="panel-shell-controls" data-no-panel-drag>
             ${options.controls ?? ""}
-            <button
+            ${collapsible ? `<button
               class="ghost panel-toggle-button"
               type="button"
               data-panel-toggle
               data-panel-title="${title}"
             >
               ${this.isPanelCollapsed(options.key) ? "펼치기" : "접기"}
-            </button>
+            </button>` : ""}
           </div>
         </div>
         <div class="panel-shell-body ${options.bodyClassName ?? ""}">
@@ -580,6 +645,7 @@ export class DomUi {
     this.renderBattle(state.battle, learnedSkills, learnedTactics);
     this.renderChat(state);
     this.renderLogs(state.logs);
+    this.syncSidePanels();
   }
 
   private renderAuth(state: AppState): void {
@@ -652,61 +718,31 @@ export class DomUi {
     const nearbyPlayers = state.presence.filter((entry) => entry.username !== state.player?.username);
     const locationTitle = currentLocation ? `${currentLocation.mainLocation} · ${currentLocation.subLocation}` : "월드 로딩 중";
     const overlayMode = state.battle ? "battle" : state.dialogue ? "dialogue" : "explore";
-    const prompt = state.fieldPrompt;
-    const controls = `
-      <span class="status-pill ${state.connectionStatus}">${state.connectionStatus}</span>
-      <span class="status-pill mode-pill mode-${overlayMode}">${overlayMode}</span>
-      <div class="layout-actions">
-        <button class="ghost" data-layout-save ${state.player ? "" : "disabled"}>UI 저장</button>
-        <button class="ghost" data-layout-load ${state.player ? "" : "disabled"}>UI 불러오기</button>
-        <button class="ghost" data-reset-layout ${state.player ? "" : "disabled"}>UI 초기화</button>
-      </div>
-      <button class="ghost" data-save ${state.player ? "" : "disabled"}>게임 저장</button>
-    `;
-    const body = `
-      <div class="meter-grid">
-        ${state.player ? this.renderPlayerMeters(state.player, nearbyPlayers.length) : this.renderLoadingMeters(state)}
-      </div>
-      ${state.player ? `<p class="panel-note">데스크톱에서는 패널 상단을 끌어 이동하고, 오른쪽 아래를 끌어 크기를 조절할 수 있습니다. 원하는 배치는 UI 저장으로 보관하고, UI 불러오기로 다시 복원할 수 있습니다.</p>` : ""}
-      ${prompt ? `
-        <div class="context-card ${prompt.tone}">
-          <div>
-            <div class="eyebrow">FIELD PROMPT</div>
-            <h3>${escapeHtml(prompt.title)}</h3>
-            <p>${escapeHtml(prompt.body)}</p>
-          </div>
-          <span class="pill">${escapeHtml(prompt.actionLabel)}</span>
-        </div>
-      ` : ""}
-    `;
+    const modeLabel = overlayMode === "battle" ? "전투" : overlayMode === "dialogue" ? "대화" : "탐험";
 
-    this.hudPanel.innerHTML = this.renderPanelFrame({
-      key: "hud",
-      eyebrow: "OVERWORLD MVP",
-      title: locationTitle,
-      titleTag: "h1",
-      subtitle: state.player ? "WASD 이동 · Space 상호작용/이야기 · Enter 전환 · B 교전" : "접속 후 오버월드 탐험이 활성화됩니다.",
-      controls,
-      body,
-    });
+    this.hudPanel.classList.add("visible");
+    this.hudPanel.innerHTML = `
+      <div class="status-bar-inner">
+        <div class="status-location">
+          <div class="eyebrow">LOCATION</div>
+          <strong>${escapeHtml(locationTitle)}</strong>
+          <span>${state.player ? escapeHtml(state.player.username) : "로그인 필요"}</span>
+        </div>
+        <div class="status-meters">
+          ${state.player ? this.renderPlayerMeters(state.player, nearbyPlayers.length) : this.renderLoadingMeters(state)}
+        </div>
+        <div class="status-actions" data-no-panel-drag>
+          <span class="status-pill ${state.connectionStatus}">${state.connectionStatus}</span>
+          <span class="status-pill mode-pill mode-${overlayMode}">${modeLabel}</span>
+          <button class="ghost" data-save ${state.player ? "" : "disabled"}>저장</button>
+        </div>
+      </div>
+    `;
 
     const saveButton = this.hudPanel.querySelector<HTMLButtonElement>("[data-save]");
     if (saveButton) {
       saveButton.onclick = () => this.callbacks.onSave();
     }
-    const layoutSaveButton = this.hudPanel.querySelector<HTMLButtonElement>("[data-layout-save]");
-    if (layoutSaveButton) {
-      layoutSaveButton.onclick = () => this.saveFloatingLayouts();
-    }
-    const layoutLoadButton = this.hudPanel.querySelector<HTMLButtonElement>("[data-layout-load]");
-    if (layoutLoadButton) {
-      layoutLoadButton.onclick = () => this.loadFloatingLayouts();
-    }
-    const resetLayoutButton = this.hudPanel.querySelector<HTMLButtonElement>("[data-reset-layout]");
-    if (resetLayoutButton) {
-      resetLayoutButton.onclick = () => this.resetFloatingLayouts();
-    }
-    this.bindPanelToggle("hud");
   }
 
   private renderActions(
@@ -718,10 +754,17 @@ export class DomUi {
     ownedEquipment: EquipmentDefinition[],
   ): void {
     const { player, battle, battleReport } = state;
+    const prompt = state.fieldPrompt;
     if (!player || !currentLocation) {
+      this.actionPanelWasVisible = false;
       this.actionPanel.classList.remove("visible");
       this.actionPanel.innerHTML = "";
       return;
+    }
+
+    if (!this.actionPanelWasVisible) {
+      this.activeSidePanel = "action";
+      this.actionPanelWasVisible = true;
     }
 
     const restingVisible = currentLocation.subLocation === "여관";
@@ -832,6 +875,7 @@ export class DomUi {
       key: "action",
       eyebrow: "FIELD ACTIONS",
       title: currentLocation.subLocation,
+      collapsible: false,
       controls: `
         <div class="dock-summary">
           <span class="pill">${escapeHtml(currentLocation.mainLocation)}</span>
@@ -839,6 +883,16 @@ export class DomUi {
         </div>
       `,
       body: `
+        ${prompt ? `
+          <div class="action-prompt ${prompt.tone}">
+            <div>
+              <div class="eyebrow">FIELD PROMPT</div>
+              <h3>${escapeHtml(prompt.title)}</h3>
+              <p>${escapeHtml(prompt.body)}</p>
+            </div>
+            <span class="pill">${escapeHtml(prompt.actionLabel)}</span>
+          </div>
+        ` : ""}
         <div class="equipment-layout">
           <section class="equipment-board" aria-label="장비창">
             <div class="inventory-section-heading">
@@ -909,6 +963,7 @@ export class DomUi {
       key: "dialogue",
       eyebrow: "DIALOGUE",
       title: state.dialogue.title,
+      collapsible: false,
       controls: `<span class="pill">${state.dialogue.index + 1} / ${state.dialogue.lines.length}</span>`,
       body: `
         <p class="dialogue-line">${escapeHtml(currentLine)}</p>
@@ -924,9 +979,15 @@ export class DomUi {
 
   private renderBattle(battle: BattleState | null, skills: SkillDefinition[], tactics: TacticDefinition[]): void {
     if (!battle) {
+      this.battlePanelWasVisible = false;
       this.battlePanel.classList.remove("visible");
       this.battlePanel.innerHTML = "";
       return;
+    }
+
+    if (!this.battlePanelWasVisible) {
+      this.activeSidePanel = "battle";
+      this.battlePanelWasVisible = true;
     }
 
     const statuses = [
@@ -941,6 +1002,7 @@ export class DomUi {
       key: "battle",
       eyebrow: "BATTLE",
       title: battle.enemy.name,
+      collapsible: false,
       controls: `<span class="pill">턴 ${battle.turnNumber}</span>`,
       body: `
         <div class="battle-showcase">
@@ -1006,10 +1068,12 @@ export class DomUi {
       ? "같은 씬의 유저에게 말하기"
       : "연결 복구 후 채팅 가능";
 
+    this.chatPanel.classList.add("visible");
     this.chatPanel.innerHTML = this.renderPanelFrame({
       key: "chat",
       eyebrow: "SOCIAL",
       title: "지역 채팅",
+      collapsible: false,
       controls: `<span class="status-pill ${state.connectionStatus}">${nearbyPlayers.length} nearby</span>`,
       body: `
         <div class="presence-strip">
@@ -1041,10 +1105,12 @@ export class DomUi {
   }
 
   private renderLogs(logs: string[]): void {
+    this.logPanel.classList.add("visible");
     this.logPanel.innerHTML = this.renderPanelFrame({
       key: "log",
       eyebrow: "EVENT FEED",
       title: "최근 이벤트",
+      collapsible: false,
       controls: `<span class="pill">${Math.min(logs.length, 6)} entries</span>`,
       body: `
         <div class="log-list">
@@ -1062,6 +1128,7 @@ export class DomUi {
       <div class="meter-card"><span>MP</span><strong>${Math.round(player.currentMp)}</strong></div>
       <div class="meter-card"><span>Coin</span><strong>${player.coins}</strong></div>
       <div class="meter-card"><span>Atk</span><strong>${player.attack}</strong></div>
+      <div class="meter-card"><span>Def</span><strong>${player.defense}</strong></div>
       <div class="meter-card"><span>Nearby</span><strong>${nearbyCount}</strong></div>
     `;
   }


### PR DESCRIPTION
## Summary
- move HUD/action/log/battle/chat panels out of the Phaser viewport into a top status bar plus left/right side rails
- add left-side menu buttons for action, battle, and log panels while keeping chat fixed to the right
- keep the viewport overlay limited to dialogue/auth flow and expose HP, Atk, Def, Coin, and nearby status in the top bar

## Verification
- corepack pnpm -r typecheck
- corepack pnpm -r lint
- corepack pnpm -r test
- corepack pnpm -r build
- Playwright smoke at 1440x900 verified left panel outside viewport, chat outside right, top status above stage, and only auth/dialogue children in .ui-layer