### PR TITLE
Add one-command local dev startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "2D browser RPG monorepo with multiplayer-ready services",
   "packageManager": "pnpm@10.32.1",
   "scripts": {
+    "dev": "corepack pnpm -r --parallel --stream --filter @rpg/server --filter @rpg/web dev",
     "dev:web": "corepack pnpm --filter @rpg/web dev",
     "dev:server": "corepack pnpm --filter @rpg/server dev",
     "build": "corepack pnpm -r build",


### PR DESCRIPTION
Summary:
- add root dev script so server and web start together from one command
- keep existing dev:web and dev:server scripts for targeted startup

Usage:
corepack pnpm dev

Verification:
- corepack pnpm dev started @rpg/server on 4000 and @rpg/web on 5173
- corepack pnpm -r typecheck
- corepack pnpm -r lint
- corepack pnpm -r test
- corepack pnpm -r build