### PR TITLE
필드 몬스터 스폰과 접촉 전투 적용

### DIFF
--- a/apps/server/src/realtime/fieldMonsters.ts
+++ b/apps/server/src/realtime/fieldMonsters.ts
@@ -1,0 +1,353 @@
+import type {
+  EncounterZone,
+  FieldMonsterClaimResult,
+  FieldMonsterState,
+  SceneDefinition,
+  WorldContent,
+} from "@rpg/game-core";
+
+const MAX_NORMAL_MONSTERS_PER_SCENE = 20;
+const MONSTER_HITBOX_SIZE = 36;
+const MONSTER_SPACING = 44;
+const BLOCKING_BUFFER = 28;
+
+type Rectangle = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+type SceneSpawnConfig = {
+  scene: SceneDefinition;
+  normalEnemyIds: string[];
+  bossEnemyId?: string;
+};
+
+type RefillOptions = {
+  fillNormal: boolean;
+  ensureBoss: boolean;
+};
+
+function expandRectangle(rectangle: Rectangle, amount: number): Rectangle {
+  return {
+    x: rectangle.x - amount,
+    y: rectangle.y - amount,
+    width: rectangle.width + amount * 2,
+    height: rectangle.height + amount * 2,
+  };
+}
+
+function rectanglesOverlap(left: Rectangle, right: Rectangle): boolean {
+  return (
+    left.x < right.x + right.width
+    && left.x + left.width > right.x
+    && left.y < right.y + right.height
+    && left.y + left.height > right.y
+  );
+}
+
+function monsterHitbox(x: number, y: number): Rectangle {
+  return {
+    x: x - MONSTER_HITBOX_SIZE / 2,
+    y: y - MONSTER_HITBOX_SIZE / 2,
+    width: MONSTER_HITBOX_SIZE,
+    height: MONSTER_HITBOX_SIZE,
+  };
+}
+
+function copyMonster(monster: FieldMonsterState): FieldMonsterState {
+  return { ...monster };
+}
+
+export class FieldMonsterManager {
+  private readonly sceneConfigs = new Map<string, SceneSpawnConfig>();
+  private readonly monstersByScene = new Map<string, FieldMonsterState[]>();
+  private nextMonsterId = 1;
+
+  constructor(
+    private readonly world: WorldContent,
+    private readonly rng: () => number = Math.random,
+  ) {
+    this.buildSceneConfigs();
+    this.refillAll({ fillNormal: true, ensureBoss: true });
+  }
+
+  getSceneMonsters(sceneId: string): FieldMonsterState[] {
+    return (this.monstersByScene.get(sceneId) ?? []).map(copyMonster);
+  }
+
+  refillAll(options: RefillOptions = { fillNormal: true, ensureBoss: true }): string[] {
+    const changedSceneIds = new Set<string>();
+    this.sceneConfigs.forEach((_config, sceneId) => {
+      if (this.refillScene(sceneId, options)) {
+        changedSceneIds.add(sceneId);
+      }
+    });
+    return Array.from(changedSceneIds);
+  }
+
+  claimMonster(sceneId: string, monsterId: string, username: string): {
+    result: FieldMonsterClaimResult;
+    changedSceneIds: string[];
+  } {
+    const monsters = this.monstersByScene.get(sceneId);
+    const monster = monsters?.find((entry) => entry.id === monsterId);
+    if (!monsters || !monster) {
+      return { result: { ok: false, reason: "not_found" }, changedSceneIds: [] };
+    }
+
+    if (monster.inBattleBy && monster.inBattleBy !== username) {
+      return { result: { ok: false, reason: "busy" }, changedSceneIds: [] };
+    }
+
+    monster.inBattleBy = username;
+    const changedSceneIds = new Set<string>([sceneId]);
+    if (monster.isBoss && this.refillScene(sceneId, { fillNormal: false, ensureBoss: true })) {
+      changedSceneIds.add(sceneId);
+    }
+
+    return {
+      result: { ok: true, monster: copyMonster(monster) },
+      changedSceneIds: Array.from(changedSceneIds),
+    };
+  }
+
+  completeBattle(monsterId: string, username: string): string[] {
+    const changedSceneIds = new Set<string>();
+    for (const [sceneId, monsters] of this.monstersByScene.entries()) {
+      const index = monsters.findIndex((monster) => monster.id === monsterId);
+      if (index < 0) {
+        continue;
+      }
+
+      const monster = monsters[index];
+      if (!monster || monster.inBattleBy !== username) {
+        return [];
+      }
+
+      monsters.splice(index, 1);
+      changedSceneIds.add(sceneId);
+      if (monster.isBoss && this.refillScene(sceneId, { fillNormal: false, ensureBoss: true })) {
+        changedSceneIds.add(sceneId);
+      }
+      return Array.from(changedSceneIds);
+    }
+    return [];
+  }
+
+  releaseBusyMonstersForUser(username: string): string[] {
+    const changedSceneIds = new Set<string>();
+    this.monstersByScene.forEach((monsters, sceneId) => {
+      let removedBoss = false;
+      for (let index = monsters.length - 1; index >= 0; index -= 1) {
+        const monster = monsters[index];
+        if (monster?.inBattleBy !== username) {
+          continue;
+        }
+        removedBoss = removedBoss || monster.isBoss;
+        monsters.splice(index, 1);
+        changedSceneIds.add(sceneId);
+      }
+
+      if (removedBoss && this.refillScene(sceneId, { fillNormal: false, ensureBoss: true })) {
+        changedSceneIds.add(sceneId);
+      }
+    });
+    return Array.from(changedSceneIds);
+  }
+
+  private buildSceneConfigs(): void {
+    Object.values(this.world.locations).forEach((location) => {
+      const scene = location.scene;
+      if (scene.encounterZones.length === 0) {
+        return;
+      }
+
+      const encounterEnemyIds = Array.from(new Set(scene.encounterZones.flatMap((zone) => zone.enemyIds)));
+      const normalEnemyIds = encounterEnemyIds.filter((enemyId) => {
+        const enemy = this.world.enemies[enemyId];
+        return Boolean(enemy && !enemy.isBoss);
+      });
+      const bossEnemyId = encounterEnemyIds.find((enemyId) => Boolean(this.world.enemies[enemyId]?.isBoss));
+      if (normalEnemyIds.length === 0 && !bossEnemyId) {
+        return;
+      }
+
+      this.sceneConfigs.set(scene.sceneId, {
+        scene,
+        normalEnemyIds,
+        bossEnemyId,
+      });
+      this.monstersByScene.set(scene.sceneId, []);
+    });
+  }
+
+  private refillScene(sceneId: string, options: RefillOptions): boolean {
+    const config = this.sceneConfigs.get(sceneId);
+    const monsters = this.monstersByScene.get(sceneId);
+    if (!config || !monsters) {
+      return false;
+    }
+
+    let changed = false;
+    if (options.fillNormal) {
+      while (monsters.filter((monster) => !monster.isBoss).length < MAX_NORMAL_MONSTERS_PER_SCENE) {
+        const spawned = this.spawnNormalMonster(config, monsters);
+        if (!spawned) {
+          break;
+        }
+        monsters.push(spawned);
+        changed = true;
+      }
+    }
+
+    if (options.ensureBoss) {
+      changed = this.ensureAvailableBoss(config, monsters) || changed;
+    }
+
+    return changed;
+  }
+
+  private spawnNormalMonster(config: SceneSpawnConfig, existingMonsters: FieldMonsterState[]): FieldMonsterState | null {
+    if (config.normalEnemyIds.length === 0) {
+      return null;
+    }
+
+    const enemyId = this.pickWeightedEnemy(config.normalEnemyIds);
+    return this.createMonster(config, enemyId, false, existingMonsters);
+  }
+
+  private ensureAvailableBoss(config: SceneSpawnConfig, existingMonsters: FieldMonsterState[]): boolean {
+    if (!config.bossEnemyId) {
+      return false;
+    }
+
+    const hasAvailableBoss = existingMonsters.some((monster) => monster.isBoss && !monster.inBattleBy);
+    if (hasAvailableBoss) {
+      return false;
+    }
+
+    const boss = this.createMonster(config, config.bossEnemyId, true, existingMonsters);
+    if (!boss) {
+      return false;
+    }
+    existingMonsters.push(boss);
+    return true;
+  }
+
+  private createMonster(
+    config: SceneSpawnConfig,
+    enemyId: string,
+    isBoss: boolean,
+    existingMonsters: FieldMonsterState[],
+  ): FieldMonsterState | null {
+    const enemy = this.world.enemies[enemyId];
+    if (!enemy) {
+      return null;
+    }
+
+    const zones = this.getZonesForEnemy(config.scene, enemyId);
+    const position = this.pickSpawnPosition(config.scene, zones, existingMonsters);
+    if (!position) {
+      return null;
+    }
+
+    return {
+      id: `field-monster-${this.nextMonsterId++}`,
+      sceneId: config.scene.sceneId,
+      enemyId,
+      enemyName: enemy.name,
+      texturePath: enemy.texturePath,
+      x: Math.round(position.x),
+      y: Math.round(position.y),
+      isBoss,
+      spawnedAt: new Date().toISOString(),
+    };
+  }
+
+  private pickWeightedEnemy(enemyIds: string[]): string {
+    const totalWeight = enemyIds.reduce((sum, enemyId) => sum + this.getSpawnWeight(enemyId), 0);
+    let threshold = this.rng() * totalWeight;
+    for (const enemyId of enemyIds) {
+      threshold -= this.getSpawnWeight(enemyId);
+      if (threshold <= 0) {
+        return enemyId;
+      }
+    }
+    return enemyIds[enemyIds.length - 1] as string;
+  }
+
+  private getSpawnWeight(enemyId: string): number {
+    const spawnRate = this.world.enemies[enemyId]?.spawnRate;
+    return typeof spawnRate === "number" && Number.isFinite(spawnRate) && spawnRate > 0 ? spawnRate : 1;
+  }
+
+  private getZonesForEnemy(scene: SceneDefinition, enemyId: string): EncounterZone[] {
+    const matchingZones = scene.encounterZones.filter((zone) => zone.enemyIds.includes(enemyId));
+    return matchingZones.length > 0 ? matchingZones : scene.encounterZones;
+  }
+
+  private pickSpawnPosition(
+    scene: SceneDefinition,
+    zones: EncounterZone[],
+    existingMonsters: FieldMonsterState[],
+  ): { x: number; y: number } | null {
+    const blockingRects = this.createBlockingRectangles(scene);
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const zone = zones[Math.floor(this.rng() * zones.length)];
+      if (!zone) {
+        return null;
+      }
+      const x = zone.x + MONSTER_HITBOX_SIZE / 2 + this.rng() * Math.max(1, zone.width - MONSTER_HITBOX_SIZE);
+      const y = zone.y + MONSTER_HITBOX_SIZE / 2 + this.rng() * Math.max(1, zone.height - MONSTER_HITBOX_SIZE);
+      if (this.canPlaceMonster(x, y, scene, blockingRects, existingMonsters)) {
+        return { x, y };
+      }
+    }
+
+    for (const zone of zones) {
+      for (let y = zone.y + MONSTER_HITBOX_SIZE / 2; y <= zone.y + zone.height - MONSTER_HITBOX_SIZE / 2; y += MONSTER_SPACING) {
+        for (let x = zone.x + MONSTER_HITBOX_SIZE / 2; x <= zone.x + zone.width - MONSTER_HITBOX_SIZE / 2; x += MONSTER_SPACING) {
+          if (this.canPlaceMonster(x, y, scene, blockingRects, existingMonsters)) {
+            return { x, y };
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+
+  private canPlaceMonster(
+    x: number,
+    y: number,
+    scene: SceneDefinition,
+    blockingRects: Rectangle[],
+    existingMonsters: FieldMonsterState[],
+  ): boolean {
+    const hitbox = monsterHitbox(x, y);
+    if (hitbox.x < 0 || hitbox.y < 0 || hitbox.x + hitbox.width > scene.width || hitbox.y + hitbox.height > scene.height) {
+      return false;
+    }
+
+    if (blockingRects.some((rectangle) => rectanglesOverlap(hitbox, rectangle))) {
+      return false;
+    }
+
+    return existingMonsters.every((monster) => {
+      const distance = Math.hypot(monster.x - x, monster.y - y);
+      return distance >= MONSTER_SPACING;
+    });
+  }
+
+  private createBlockingRectangles(scene: SceneDefinition): Rectangle[] {
+    const npcBlocks = scene.npcs.map((npc) =>
+      expandRectangle({ x: npc.x - 24, y: npc.y - 32, width: 48, height: 64 }, BLOCKING_BUFFER),
+    );
+    const portalBlocks = scene.portals.map((portal) => expandRectangle(portal, BLOCKING_BUFFER));
+    const collisionBlocks = scene.collisionZones.map((zone) => expandRectangle(zone, 6));
+    const spawnBlock = expandRectangle({ x: scene.spawn.x - 28, y: scene.spawn.y - 28, width: 56, height: 56 }, 18);
+    return [...npcBlocks, ...portalBlocks, ...collisionBlocks, spawnBlock];
+  }
+}

--- a/apps/server/src/realtime/presence.ts
+++ b/apps/server/src/realtime/presence.ts
@@ -2,12 +2,14 @@ import type { Server } from "socket.io";
 import {
   isPlayerAvatarId,
   type ChatMessage,
+  type FieldMonsterClaimResult,
   type Facing,
   type PresenceState,
   type WorldContent,
 } from "@rpg/game-core";
 import type { ServerEnv } from "../config/env";
 import { verifyToken } from "../http/auth";
+import { FieldMonsterManager } from "./fieldMonsters";
 
 type AuthenticatedSocketData = {
   username: string;
@@ -32,8 +34,11 @@ type PresencePayload = {
   avatarId: string;
 };
 
+type FieldMonsterClaimAck = (result: FieldMonsterClaimResult) => void;
+
 const FACING_VALUES = new Set<Facing>(["up", "down", "left", "right"]);
 const MAX_CHAT_LENGTH = 200;
+const FIELD_MONSTER_REFILL_INTERVAL_MS = 10_000;
 
 function colorFromUsername(username: string): string {
   const palette = ["#f25f5c", "#247ba0", "#70c1b3", "#ffe066", "#50514f", "#f79d65"];
@@ -130,9 +135,16 @@ function readChatText(payload: unknown): string | null {
   return text;
 }
 
+function readFieldMonsterId(payload: unknown): string | null {
+  const record = asRecord(payload);
+  const monsterId = typeof record?.monsterId === "string" ? record.monsterId.trim() : "";
+  return monsterId.length > 0 ? monsterId : null;
+}
+
 export function configureRealtime(io: Server, env: ServerEnv, world: WorldContent): void {
   const presenceByScene = new Map<string, Map<string, PresenceEntry>>();
   const sceneBounds = buildSceneBounds(world);
+  const fieldMonsters = new FieldMonsterManager(world);
 
   const serializeRoom = (room: Map<string, PresenceEntry>): PresenceState[] =>
     Array.from(room.values()).map((entry) => ({
@@ -145,6 +157,19 @@ export function configureRealtime(io: Server, env: ServerEnv, world: WorldConten
       avatarId: entry.avatarId,
       updatedAt: entry.updatedAt,
     }));
+
+  const broadcastFieldMonsterScenes = (sceneIds: string[]) => {
+    sceneIds.forEach((sceneId) => {
+      io.to(sceneId).emit("field-monsters:update", fieldMonsters.getSceneMonsters(sceneId));
+    });
+  };
+
+  const fieldMonsterRefillTimer = setInterval(() => {
+    broadcastFieldMonsterScenes(fieldMonsters.refillAll());
+  }, FIELD_MONSTER_REFILL_INTERVAL_MS);
+  if (typeof fieldMonsterRefillTimer === "object" && "unref" in fieldMonsterRefillTimer) {
+    fieldMonsterRefillTimer.unref();
+  }
 
   io.use((socket, next) => {
     const token = String(socket.handshake.auth.token ?? "");
@@ -212,6 +237,7 @@ export function configureRealtime(io: Server, env: ServerEnv, world: WorldConten
       presenceByScene.set(sceneId, room);
 
       socket.emit("presence:snapshot", serializeRoom(room));
+      socket.emit("field-monsters:snapshot", fieldMonsters.getSceneMonsters(sceneId));
       socket.to(sceneId).emit(hadExisting ? "presence:update" : "presence:joined", state);
     };
 
@@ -287,7 +313,33 @@ export function configureRealtime(io: Server, env: ServerEnv, world: WorldConten
       io.to(data.sceneId).emit("chat:message", message);
     });
 
+    socket.on("field-monsters:claim", (payload: unknown, ack?: FieldMonsterClaimAck) => {
+      if (!data.sceneId) {
+        ack?.({ ok: false, reason: "invalid_scene" });
+        return;
+      }
+
+      const monsterId = readFieldMonsterId(payload);
+      if (!monsterId) {
+        ack?.({ ok: false, reason: "not_found" });
+        return;
+      }
+
+      const { result, changedSceneIds } = fieldMonsters.claimMonster(data.sceneId, monsterId, data.username);
+      ack?.(result);
+      broadcastFieldMonsterScenes(changedSceneIds);
+    });
+
+    socket.on("field-monsters:release", (payload: unknown) => {
+      const monsterId = readFieldMonsterId(payload);
+      if (!monsterId) {
+        return;
+      }
+      broadcastFieldMonsterScenes(fieldMonsters.completeBattle(monsterId, data.username));
+    });
+
     socket.on("disconnect", () => {
+      broadcastFieldMonsterScenes(fieldMonsters.releaseBusyMonstersForUser(data.username));
       leaveCurrentScene();
     });
   });

--- a/apps/server/test/realtime.test.ts
+++ b/apps/server/test/realtime.test.ts
@@ -1,7 +1,7 @@
 import type { AddressInfo } from "node:net";
 import { io as createClient, type Socket as ClientSocket } from "socket.io-client";
 import { describe, expect, it } from "vitest";
-import type { PresenceState, WorldContent } from "@rpg/game-core";
+import type { FieldMonsterClaimResult, FieldMonsterState, PresenceState, WorldContent } from "@rpg/game-core";
 import { createStarterPlayer, DEFAULT_PLAYER_AVATAR_ID } from "@rpg/game-core";
 import { createAppContext } from "../src/app";
 import { signToken } from "../src/http/auth";
@@ -54,6 +54,131 @@ function createWorld(): WorldContent {
   };
 }
 
+function createFieldMonsterWorld(options: { boss?: boolean } = {}): WorldContent {
+  const startLocationKey = "field::monster-zone";
+  const slimeId = "enemy-slime";
+  const wispId = "enemy-wisp";
+  const bossId = "boss-warden";
+  const enemyIds = options.boss ? [bossId] : [slimeId, wispId];
+  return {
+    startLocationKey,
+    locations: {
+      [startLocationKey]: {
+        key: startLocationKey,
+        mainLocation: "field",
+        subLocation: "monster-zone",
+        story: [],
+        bossName: options.boss ? "Warden" : undefined,
+        connections: [],
+        scene: {
+          sceneId: "scene-field",
+          themeId: "forest",
+          width: 1024,
+          height: 768,
+          tileSize: 32,
+          backgroundColor: "#10231b",
+          spawn: { x: 72, y: 72 },
+          portals: [
+            {
+              id: "portal-safe",
+              label: "safe",
+              toLocationKey: startLocationKey,
+              x: 32,
+              y: 300,
+              width: 72,
+              height: 112,
+            },
+          ],
+          npcs: [
+            {
+              id: "npc-keeper",
+              name: "Keeper",
+              x: 840,
+              y: 240,
+              texturePath: "/npc.svg",
+              lines: ["Stay alert."],
+            },
+          ],
+          encounterZones: [
+            {
+              id: "encounter-field",
+              x: 180,
+              y: 170,
+              width: 560,
+              height: 420,
+              enemyIds,
+            },
+          ],
+          collisionZones: [],
+          assets: {
+            layoutId: options.boss ? "boss_arena" : "field",
+            mapJsonPath: "/maps/test.json",
+            terrainTexturePath: "/terrain.svg",
+            propsTexturePath: "/props.svg",
+            playerTexturePath: "/player.svg",
+            remotePlayerTexturePath: "/remote.svg",
+            npcTexturePath: "/npc.svg",
+            portalTexturePath: "/portal.svg",
+            encounterTexturePath: "/encounter.svg",
+            license: "placeholder",
+            attribution: "test",
+          },
+        },
+      },
+    },
+    equipment: [],
+    skills: [],
+    tactics: [],
+    enemies: {
+      [slimeId]: {
+        id: slimeId,
+        name: "Slime",
+        texturePath: "/slime.svg",
+        spawnRate: 1,
+        maxHp: 10,
+        attack: 2,
+        defense: 0,
+        speed: 1,
+        accuracy: 1,
+        mana: 0,
+        experienceReward: 1,
+        coinReward: 1,
+      },
+      [wispId]: {
+        id: wispId,
+        name: "Wisp",
+        texturePath: "/wisp.svg",
+        spawnRate: 3,
+        maxHp: 12,
+        attack: 3,
+        defense: 0,
+        speed: 2,
+        accuracy: 1,
+        mana: 0,
+        experienceReward: 2,
+        coinReward: 2,
+      },
+      [bossId]: {
+        id: bossId,
+        name: "Warden",
+        texturePath: "/warden.svg",
+        maxHp: 40,
+        attack: 6,
+        defense: 2,
+        speed: 1,
+        accuracy: 1,
+        mana: 0,
+        experienceReward: 10,
+        coinReward: 10,
+        isBoss: true,
+      },
+    },
+    enemiesByLocation: {
+      [startLocationKey]: enemyIds,
+    },
+  };
+}
+
 function onceEvent<T>(socket: ClientSocket, eventName: string, timeoutMs = 5_000): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const timer = setTimeout(() => {
@@ -70,6 +195,19 @@ function onceEvent<T>(socket: ClientSocket, eventName: string, timeoutMs = 5_000
   });
 }
 
+function emitAck<T>(socket: ClientSocket, eventName: string, payload: unknown, timeoutMs = 5_000): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Timed out waiting for ${eventName} ack.`));
+    }, timeoutMs);
+
+    socket.emit(eventName, payload, (result: unknown) => {
+      clearTimeout(timer);
+      resolve(result as T);
+    });
+  });
+}
+
 async function connectClient(baseUrl: string, token: string): Promise<ClientSocket> {
   const socket = createClient(baseUrl, { auth: { token } });
   await new Promise<void>((resolve, reject) => {
@@ -77,6 +215,27 @@ async function connectClient(baseUrl: string, token: string): Promise<ClientSock
     socket.once("connect_error", reject);
   });
   return socket;
+}
+
+function monsterHitbox(monster: FieldMonsterState): { x: number; y: number; width: number; height: number } {
+  return {
+    x: monster.x - 18,
+    y: monster.y - 18,
+    width: 36,
+    height: 36,
+  };
+}
+
+function rectanglesOverlap(
+  left: { x: number; y: number; width: number; height: number },
+  right: { x: number; y: number; width: number; height: number },
+): boolean {
+  return (
+    left.x < right.x + right.width
+    && left.x + left.width > right.x
+    && left.y < right.y + right.height
+    && left.y + left.height > right.y
+  );
 }
 
 async function waitForTick(duration = 120): Promise<void> {
@@ -311,6 +470,163 @@ describe("realtime presence", () => {
 
       expect(chat.text).toBe("복귀 완료");
       expect(leftUsername).toBeNull();
+    } finally {
+      sockets.forEach((socket) => socket.disconnect());
+      await new Promise<void>((resolve, reject) => context.httpServer.close((error) => (error ? reject(error) : resolve())));
+    }
+  }, 15_000);
+
+  it("shares field monsters and blocks duplicate claims on busy monsters", async () => {
+    const repository = new MemoryUserRepository();
+    const world = createFieldMonsterWorld();
+    const env = {
+      runtimeMode: "test" as const,
+      port: 0,
+      clientOrigin: "http://localhost:5173",
+      jwtSecret: "0123456789abcdef0123456789abcdef",
+      jwtExpiresIn: "7d",
+      passwordHashRounds: 10,
+      storageDriver: "memory" as const,
+    };
+
+    await repository.saveAccount({
+      username: "hero-a",
+      passwordHash: "plain",
+      player: createStarterPlayer("hero-a", world),
+    });
+    await repository.saveAccount({
+      username: "hero-b",
+      passwordHash: "plain",
+      player: createStarterPlayer("hero-b", world),
+    });
+
+    const context = await createAppContext({
+      env,
+      repository,
+      worldLoader: async () => world,
+    });
+
+    await new Promise<void>((resolve) => context.httpServer.listen(0, resolve));
+    const address = context.httpServer.address() as AddressInfo;
+    const baseUrl = `http://127.0.0.1:${address.port}`;
+    const sockets: ClientSocket[] = [];
+
+    try {
+      const socketA = await connectClient(baseUrl, signToken(env, "hero-a"));
+      const socketB = await connectClient(baseUrl, signToken(env, "hero-b"));
+      sockets.push(socketA, socketB);
+
+      const snapshotA = onceEvent<FieldMonsterState[]>(socketA, "field-monsters:snapshot");
+      socketA.emit("presence:join", { sceneId: "scene-field", x: 72, y: 72, facing: "down", avatarId: DEFAULT_PLAYER_AVATAR_ID });
+      const monsters = await snapshotA;
+      const normalMonsters = monsters.filter((monster) => !monster.isBoss);
+
+      expect(normalMonsters).toHaveLength(20);
+      expect(normalMonsters.every((monster) => monster.sceneId === "scene-field")).toBe(true);
+      const location = world.locations[world.startLocationKey]!;
+      const portal = location.scene.portals[0]!;
+      const npcBlock = { x: 816, y: 208, width: 48, height: 64 };
+      normalMonsters.forEach((monster) => {
+        expect(rectanglesOverlap(monsterHitbox(monster), portal)).toBe(false);
+        expect(rectanglesOverlap(monsterHitbox(monster), npcBlock)).toBe(false);
+      });
+
+      const snapshotB = onceEvent<FieldMonsterState[]>(socketB, "field-monsters:snapshot");
+      socketB.emit("presence:join", { sceneId: "scene-field", x: 90, y: 72, facing: "down", avatarId: DEFAULT_PLAYER_AVATAR_ID });
+      await snapshotB;
+
+      const target = normalMonsters[0]!;
+      const claimA = await emitAck<FieldMonsterClaimResult>(socketA, "field-monsters:claim", { monsterId: target.id });
+      if (!claimA.ok) {
+        throw new Error(`Expected first claim to succeed, got ${claimA.reason}.`);
+      }
+      expect(claimA.monster.id).toBe(target.id);
+
+      const claimB = await emitAck<FieldMonsterClaimResult>(socketB, "field-monsters:claim", { monsterId: target.id });
+      expect(claimB).toEqual({ ok: false, reason: "busy" });
+
+      const releaseUpdate = onceEvent<FieldMonsterState[]>(socketB, "field-monsters:update");
+      socketA.emit("field-monsters:release", { monsterId: target.id });
+      const afterRelease = await releaseUpdate;
+      expect(afterRelease.some((monster) => monster.id === target.id)).toBe(false);
+      expect(afterRelease.filter((monster) => !monster.isBoss)).toHaveLength(19);
+    } finally {
+      sockets.forEach((socket) => socket.disconnect());
+      await new Promise<void>((resolve, reject) => context.httpServer.close((error) => (error ? reject(error) : resolve())));
+    }
+  }, 15_000);
+
+  it("keeps one available boss even while another boss instance is in battle", async () => {
+    const repository = new MemoryUserRepository();
+    const world = createFieldMonsterWorld({ boss: true });
+    const env = {
+      runtimeMode: "test" as const,
+      port: 0,
+      clientOrigin: "http://localhost:5173",
+      jwtSecret: "0123456789abcdef0123456789abcdef",
+      jwtExpiresIn: "7d",
+      passwordHashRounds: 10,
+      storageDriver: "memory" as const,
+    };
+
+    await repository.saveAccount({
+      username: "hero-a",
+      passwordHash: "plain",
+      player: createStarterPlayer("hero-a", world),
+    });
+    await repository.saveAccount({
+      username: "hero-b",
+      passwordHash: "plain",
+      player: createStarterPlayer("hero-b", world),
+    });
+
+    const context = await createAppContext({
+      env,
+      repository,
+      worldLoader: async () => world,
+    });
+
+    await new Promise<void>((resolve) => context.httpServer.listen(0, resolve));
+    const address = context.httpServer.address() as AddressInfo;
+    const baseUrl = `http://127.0.0.1:${address.port}`;
+    const sockets: ClientSocket[] = [];
+
+    try {
+      const socketA = await connectClient(baseUrl, signToken(env, "hero-a"));
+      const socketB = await connectClient(baseUrl, signToken(env, "hero-b"));
+      sockets.push(socketA, socketB);
+
+      const snapshotA = onceEvent<FieldMonsterState[]>(socketA, "field-monsters:snapshot");
+      socketA.emit("presence:join", { sceneId: "scene-field", x: 72, y: 72, facing: "down", avatarId: DEFAULT_PLAYER_AVATAR_ID });
+      const initialBosses = await snapshotA;
+      expect(initialBosses.filter((monster) => monster.isBoss)).toHaveLength(1);
+
+      const snapshotB = onceEvent<FieldMonsterState[]>(socketB, "field-monsters:snapshot");
+      socketB.emit("presence:join", { sceneId: "scene-field", x: 90, y: 72, facing: "down", avatarId: DEFAULT_PLAYER_AVATAR_ID });
+      await snapshotB;
+
+      const firstBoss = initialBosses.find((monster) => monster.isBoss)!;
+      const bossUpdate = onceEvent<FieldMonsterState[]>(socketB, "field-monsters:update");
+      const claimA = await emitAck<FieldMonsterClaimResult>(socketA, "field-monsters:claim", { monsterId: firstBoss.id });
+      if (!claimA.ok) {
+        throw new Error(`Expected boss claim to succeed, got ${claimA.reason}.`);
+      }
+
+      const bossesAfterClaim = await bossUpdate;
+      const availableBoss = bossesAfterClaim.find((monster) => monster.isBoss && !monster.inBattleBy);
+      expect(bossesAfterClaim.filter((monster) => monster.isBoss)).toHaveLength(2);
+      expect(availableBoss).toBeTruthy();
+
+      const secondClaimUpdate = onceEvent<FieldMonsterState[]>(socketA, "field-monsters:update");
+      const claimB = await emitAck<FieldMonsterClaimResult>(socketB, "field-monsters:claim", { monsterId: availableBoss!.id });
+      expect(claimB.ok).toBe(true);
+      await secondClaimUpdate;
+
+      const releaseUpdate = onceEvent<FieldMonsterState[]>(socketB, "field-monsters:update");
+      socketA.emit("field-monsters:release", { monsterId: firstBoss.id });
+      const bossesAfterRelease = await releaseUpdate;
+      expect(bossesAfterRelease.some((monster) => monster.id === firstBoss.id)).toBe(false);
+      expect(bossesAfterRelease.some((monster) => monster.isBoss && !monster.inBattleBy)).toBe(true);
     } finally {
       sockets.forEach((socket) => socket.disconnect());
       await new Promise<void>((resolve, reject) => context.httpServer.close((error) => (error ? reject(error) : resolve())));

--- a/apps/web/src/AppController.ts
+++ b/apps/web/src/AppController.ts
@@ -1,9 +1,9 @@
 import type {
   BattleAction,
   DialogueNpc,
-  EncounterZone,
   EquipmentDefinition,
   Facing,
+  FieldMonsterState,
   LocationNode,
   PlayerSave,
   PresenceState,
@@ -19,7 +19,6 @@ import {
   getMaxMp,
   PLAYER_AVATAR_IDS,
   performBattleAction,
-  pickRandom,
   toggleEquippedEquipmentId,
 } from "@rpg/game-core";
 import { validateAuthCredentials } from "./auth";
@@ -44,7 +43,12 @@ function pickPlayerAvatarId(): string {
 }
 
 type GameRuntime = {
-  sync: (world: WorldContent | null, player: PlayerSave | null, nearbyPlayers: PresenceState[]) => void;
+  sync: (
+    world: WorldContent | null,
+    player: PlayerSave | null,
+    nearbyPlayers: PresenceState[],
+    fieldMonsters: FieldMonsterState[],
+  ) => void;
   destroy: () => void;
 };
 
@@ -58,7 +62,7 @@ type GameBridgeCallbacks = {
   onSceneChange: (locationKey: string) => void;
   onOpenLocationStory: () => void;
   onInteractNpc: (npc: DialogueNpc) => void;
-  onEncounter: (zone: EncounterZone) => void;
+  onFieldMonsterContact: (monster: FieldMonsterState) => void;
   onFieldPromptChange: (prompt: FieldPrompt) => void;
 };
 
@@ -72,6 +76,8 @@ export class AppController {
   private hasRetriedGameLoad = false;
   private readonly playerAvatarId = pickPlayerAvatarId();
   private readonly presence: PresenceClient;
+  private activeFieldMonsterId: string | null = null;
+  private pendingFieldMonsterId: string | null = null;
   private lastSavedAt = 0;
   private readonly handleGlobalKeydown = (event: KeyboardEvent) => {
     if (this.isGameplayInputBlocked(event.target)) {
@@ -142,6 +148,8 @@ export class AppController {
           chatMessages: [...state.chatMessages, message].slice(-40),
         }));
       },
+      onFieldMonstersSnapshot: (snapshot) => this.setFieldMonsters(snapshot),
+      onFieldMonstersUpdate: (snapshot) => this.setFieldMonsters(snapshot),
       onConnect: () => this.handleRealtimeConnect(),
       onDisconnect: (reason) => this.handleRealtimeDisconnect(reason),
       onConnectError: (message) => this.handleRealtimeConnectError(message),
@@ -176,7 +184,7 @@ export class AppController {
         : [];
 
       this.ui.render(state, currentLocation, equipmentForLocation, skillsForLocation, equipped, ownedEquipment, learnedSkills, learnedTactics);
-      this.game?.sync(state.world, state.player, state.presence);
+      this.game?.sync(state.world, state.player, state.presence, state.fieldMonsters);
     });
 
     window.addEventListener("keydown", this.handleGlobalKeydown);
@@ -257,8 +265,8 @@ export class AppController {
       },
       onOpenLocationStory: () => this.openCurrentLocationStory(),
       onInteractNpc: (npc) => this.openNpcDialogue(npc),
-      onEncounter: (zone) => {
-        void this.startEncounter(zone);
+      onFieldMonsterContact: (monster) => {
+        void this.startFieldMonsterBattle(monster);
       },
       onFieldPromptChange: (prompt) => this.store.setState({ fieldPrompt: prompt }),
     };
@@ -280,7 +288,7 @@ export class AppController {
             this.gameRetryTimer = null;
           }
           const state = this.store.getState();
-          game.sync(state.world, state.player, state.presence);
+          game.sync(state.world, state.player, state.presence, state.fieldMonsters);
           return game;
         })
         .catch((error) => {
@@ -329,6 +337,7 @@ export class AppController {
         dialogue: null,
         chatMessages: [],
         presence: [],
+        fieldMonsters: [],
         pending: false,
       });
       this.loadGameBridge();
@@ -383,6 +392,7 @@ export class AppController {
       player: nextPlayer,
       battleReport: null,
       presence: [],
+      fieldMonsters: [],
       chatMessages: [],
     });
     this.enterPresence(nextPlayer, true);
@@ -479,20 +489,39 @@ export class AppController {
     }
   }
 
-  private async startEncounter(zone: EncounterZone): Promise<void> {
+  private async startFieldMonsterBattle(monster: FieldMonsterState): Promise<void> {
     const state = this.store.getState();
-    if (!state.player || state.battle) {
+    if (!state.player || state.battle || this.activeFieldMonsterId || this.pendingFieldMonsterId) {
       return;
     }
 
-    const enemyId = pickRandom(zone.enemyIds, Math.random);
-    const enemy = this.world.enemies[enemyId];
+    this.pendingFieldMonsterId = monster.id;
+    const claim = await this.presence.claimFieldMonster(monster.id);
+    this.pendingFieldMonsterId = null;
+
+    if (!claim.ok) {
+      if (claim.reason === "busy") {
+        this.store.pushLog(`${monster.enemyName}은 이미 다른 전투에 묶여 있습니다.`);
+      }
+      return;
+    }
+
+    const nextState = this.store.getState();
+    const currentSceneId = nextState.player ? this.world.locations[nextState.player.locationKey]?.scene.sceneId : null;
+    if (!nextState.player || nextState.battle || currentSceneId !== claim.monster.sceneId) {
+      this.presence.releaseFieldMonster(claim.monster.id);
+      return;
+    }
+
+    const enemy = this.world.enemies[claim.monster.enemyId];
     if (!enemy) {
+      this.presence.releaseFieldMonster(claim.monster.id);
       return;
     }
 
+    this.activeFieldMonsterId = claim.monster.id;
     this.store.setState({
-      battle: createBattle(state.player, enemy),
+      battle: createBattle(nextState.player, enemy),
       battleReport: null,
     });
     this.store.pushLog(`${enemy.name}과(와) 전투를 시작합니다.`);
@@ -531,6 +560,7 @@ export class AppController {
     }
 
     const sceneChangedAfterBattle = didSceneChange(this.world, previousPlayer, nextPlayer);
+    const completedFieldMonsterId = resolution.state.finished ? this.activeFieldMonsterId : null;
     const battleReport = createBattleReport({
       ...resolution,
       player: nextPlayer,
@@ -547,6 +577,10 @@ export class AppController {
     if (sceneChangedAfterBattle) {
       this.enterPresence(nextPlayer, true);
       this.syncLocationStoryState(nextPlayer.locationKey);
+    }
+    if (completedFieldMonsterId) {
+      this.presence.releaseFieldMonster(completedFieldMonsterId);
+      this.activeFieldMonsterId = null;
     }
     await this.savePlayer();
   }
@@ -702,6 +736,7 @@ export class AppController {
     this.store.setState({
       connectionStatus: "offline",
       presence: [],
+      fieldMonsters: [],
     });
 
     if (shouldLog) {
@@ -714,6 +749,7 @@ export class AppController {
     this.store.setState({
       connectionStatus: "offline",
       presence: [],
+      fieldMonsters: [],
     });
 
     if (state.player) {
@@ -723,6 +759,10 @@ export class AppController {
 
   private setPresence(snapshot: PresenceState[]): void {
     this.store.setState({ presence: snapshot });
+  }
+
+  private setFieldMonsters(snapshot: FieldMonsterState[]): void {
+    this.store.setState({ fieldMonsters: snapshot });
   }
 
   private handlePresenceJoined(presence: PresenceState): void {

--- a/apps/web/src/game/GameBridge.ts
+++ b/apps/web/src/game/GameBridge.ts
@@ -1,5 +1,12 @@
 import type Phaser from "phaser";
-import type { DialogueNpc, EncounterZone, Facing, PlayerSave, PresenceState, WorldContent } from "@rpg/game-core";
+import type {
+  DialogueNpc,
+  Facing,
+  FieldMonsterState,
+  PlayerSave,
+  PresenceState,
+  WorldContent,
+} from "@rpg/game-core";
 import type { FieldPrompt, OverlayMode } from "../gameplay";
 import type { OverworldScene } from "./OverworldScene";
 import { INITIAL_SCENE, shouldDisableGlobalKeyboardCapture, type ManagedSceneKey } from "./sceneFlow";
@@ -14,7 +21,7 @@ type BridgeCallbacks = {
   onSceneChange: (locationKey: string) => void;
   onOpenLocationStory: () => void;
   onInteractNpc: (npc: DialogueNpc) => void;
-  onEncounter: (zone: EncounterZone) => void;
+  onFieldMonsterContact: (monster: FieldMonsterState) => void;
   onFieldPromptChange: (prompt: FieldPrompt) => void;
 };
 
@@ -72,7 +79,12 @@ export class GameBridge {
     return bridge;
   }
 
-  sync(world: WorldContent | null, player: PlayerSave | null, nearbyPlayers: PresenceState[]): void {
+  sync(
+    world: WorldContent | null,
+    player: PlayerSave | null,
+    nearbyPlayers: PresenceState[],
+    fieldMonsters: FieldMonsterState[],
+  ): void {
     if (!world) {
       return;
     }
@@ -83,7 +95,7 @@ export class GameBridge {
     }
 
     this.overworldScene.attach(world, player, this.callbacks);
-    this.overworldScene.sync(player, nearbyPlayers);
+    this.overworldScene.sync(player, nearbyPlayers, fieldMonsters);
     this.ensureScene("overworld");
   }
 

--- a/apps/web/src/game/OverworldScene.ts
+++ b/apps/web/src/game/OverworldScene.ts
@@ -4,6 +4,7 @@ import {
   type DialogueNpc,
   type EncounterZone,
   type Facing,
+  type FieldMonsterState,
   type PlayerSave,
   type PresenceState,
   type SceneDefinition,
@@ -21,7 +22,7 @@ type SceneCallbacks = {
   onSceneChange: (locationKey: string) => void;
   onOpenLocationStory: () => void;
   onInteractNpc: (npc: DialogueNpc) => void;
-  onEncounter: (zone: EncounterZone) => void;
+  onFieldMonsterContact: (monster: FieldMonsterState) => void;
   onFieldPromptChange: (prompt: FieldPrompt) => void;
 };
 
@@ -59,8 +60,18 @@ type RemotePlayerSprite = {
   targetY: number;
 };
 
+type FieldMonsterSprite = {
+  container: Phaser.GameObjects.Container;
+  sprite: Phaser.GameObjects.Sprite;
+  label: Phaser.GameObjects.Text;
+  texturePath: string;
+};
+
 const REMOTE_INTERPOLATION_SPEED = 12;
 const REMOTE_SNAP_DISTANCE = 240;
+const MONSTER_CONTACT_DISTANCE = 42;
+const BOSS_CONTACT_DISTANCE = 58;
+const MONSTER_CONTACT_COOLDOWN_MS = 1200;
 
 export class OverworldScene extends Phaser.Scene {
   private world: WorldContent | null = null;
@@ -69,6 +80,8 @@ export class OverworldScene extends Phaser.Scene {
   private callbacks: SceneCallbacks | null = null;
   private playerSprite!: Phaser.GameObjects.Sprite;
   private remoteSprites = new Map<string, RemotePlayerSprite>();
+  private fieldMonsterSprites = new Map<string, FieldMonsterSprite>();
+  private fieldMonsters: FieldMonsterState[] = [];
   private portals: Array<{ zone: Phaser.Geom.Rectangle; locationKey: string; label: string }> = [];
   private encounterZones: Array<{ zone: Phaser.Geom.Rectangle; data: EncounterZone }> = [];
   private collisionZones: Phaser.Geom.Rectangle[] = [];
@@ -80,13 +93,14 @@ export class OverworldScene extends Phaser.Scene {
   private keyD!: Phaser.Input.Keyboard.Key;
   private keyEnter!: Phaser.Input.Keyboard.Key;
   private keySpace!: Phaser.Input.Keyboard.Key;
-  private keyBattle!: Phaser.Input.Keyboard.Key;
   private hintText!: Phaser.GameObjects.Text;
   private overlayShade!: Phaser.GameObjects.Rectangle;
   private overlayText!: Phaser.GameObjects.Text;
   private lastPresenceSentAt = 0;
   private lastBroadcastKey = "";
   private lastPromptKey = "";
+  private lastFieldMonsterContactId = "";
+  private lastFieldMonsterContactAt = 0;
   private gameplayCaptureDisabled = false;
 
   constructor() {
@@ -101,7 +115,6 @@ export class OverworldScene extends Phaser.Scene {
     this.keyD = this.input.keyboard!.addKey("D");
     this.keyEnter = this.input.keyboard!.addKey("ENTER");
     this.keySpace = this.input.keyboard!.addKey("SPACE");
-    this.keyBattle = this.input.keyboard!.addKey("B");
     this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
       this.input.keyboard?.resetKeys();
       this.gameplayCaptureDisabled = false;
@@ -125,16 +138,18 @@ export class OverworldScene extends Phaser.Scene {
     }
   }
 
-  sync(player: PlayerSave, nearbyPlayers: PresenceState[]): void {
+  sync(player: PlayerSave, nearbyPlayers: PresenceState[], fieldMonsters: FieldMonsterState[]): void {
     this.playerState = player;
     const location = this.world?.locations[player.locationKey];
     if (location && location.scene.sceneId !== this.sceneDefinition?.sceneId) {
       this.buildLocation();
     }
+    this.fieldMonsters = fieldMonsters.filter((monster) => monster.sceneId === this.sceneDefinition?.sceneId);
 
     if (this.playerSprite) {
       this.playerSprite.setPosition(player.position.x, player.position.y);
     }
+    this.syncFieldMonsterSprites(this.fieldMonsters);
 
     const activeUsers = new Set<string>();
     nearbyPlayers
@@ -207,14 +222,13 @@ export class OverworldScene extends Phaser.Scene {
 
     const activePortal = this.findActivePortal(nextX, nextY);
     const activeNpc = this.findActiveNpc(nextX, nextY);
-    const activeEncounter = this.findActiveEncounter(nextX, nextY);
+    const activeFieldMonster = this.findActiveFieldMonster(nextX, nextY);
     const hasPendingLocationStory = this.callbacks.hasPendingLocationStory();
     const prompt = this.resolvePrompt({
       overlayMode,
       hasPendingLocationStory,
       portal: activePortal,
       npc: activeNpc?.npc ?? null,
-      encounter: activeEncounter?.data ?? null,
     });
     this.syncFieldPrompt(prompt);
     this.syncOverlayState(overlayMode);
@@ -241,9 +255,18 @@ export class OverworldScene extends Phaser.Scene {
       return;
     }
 
-    if (activeEncounter && Phaser.Input.Keyboard.JustDown(this.keyBattle)) {
-      this.callbacks.onEncounter(activeEncounter.data);
+    if (activeFieldMonster) {
+      const shouldContact = this.lastFieldMonsterContactId !== activeFieldMonster.id
+        || time - this.lastFieldMonsterContactAt > MONSTER_CONTACT_COOLDOWN_MS;
+      if (shouldContact) {
+        this.lastFieldMonsterContactId = activeFieldMonster.id;
+        this.lastFieldMonsterContactAt = time;
+        this.callbacks.onFieldMonsterContact(activeFieldMonster);
+      }
+      return;
     }
+
+    this.lastFieldMonsterContactId = "";
   }
 
   private syncRemotePresence(presence: PresenceState): void {
@@ -300,6 +323,61 @@ export class OverworldScene extends Phaser.Scene {
     });
   }
 
+  private syncFieldMonsterSprites(monsters: FieldMonsterState[]): void {
+    if (!this.sceneDefinition) {
+      return;
+    }
+
+    const activeIds = new Set<string>();
+    monsters.forEach((monster) => {
+      activeIds.add(monster.id);
+      const existing = this.fieldMonsterSprites.get(monster.id);
+      if (existing) {
+        existing.container.setPosition(monster.x, monster.y);
+        existing.container.setAlpha(monster.inBattleBy ? 0.42 : 1);
+        existing.label.setText(monster.inBattleBy ? `${monster.enemyName} (전투 중)` : monster.enemyName);
+        if (existing.texturePath !== monster.texturePath) {
+          existing.sprite.setTexture(monster.texturePath);
+          existing.texturePath = monster.texturePath;
+        }
+        return;
+      }
+
+      const displaySize = monster.isBoss ? 56 : 40;
+      const shadow = this.add.ellipse(0, displaySize / 2 - 6, displaySize * 0.8, 12, 0x06100d, 0.38);
+      const sprite = this.add
+        .sprite(0, 0, monster.texturePath)
+        .setDisplaySize(displaySize, displaySize);
+      if (monster.isBoss) {
+        sprite.setTint(0xffe08a);
+      }
+      const label = this.createReadableLabel(0, -displaySize / 2 - 8, monster.enemyName, {
+        backgroundColor: monster.isBoss ? "rgba(66, 28, 16, 0.92)" : "rgba(8, 22, 17, 0.9)",
+        color: monster.isBoss ? "#fff1b8" : "#f8fafc",
+        depth: monster.isBoss ? 8 : 6,
+        fontSize: monster.isBoss ? "12px" : "11px",
+        originY: 1,
+      });
+      const container = this.add
+        .container(monster.x, monster.y, [shadow, sprite, label])
+        .setDepth(monster.isBoss ? 7 : 5)
+        .setAlpha(monster.inBattleBy ? 0.42 : 1);
+      this.fieldMonsterSprites.set(monster.id, {
+        container,
+        sprite,
+        label,
+        texturePath: monster.texturePath,
+      });
+    });
+
+    Array.from(this.fieldMonsterSprites.entries()).forEach(([monsterId, rendered]) => {
+      if (!activeIds.has(monsterId)) {
+        rendered.container.destroy();
+        this.fieldMonsterSprites.delete(monsterId);
+      }
+    });
+  }
+
   private syncGameplayCapture(gameplayInputBlocked: boolean): void {
     const keyboard = this.input.keyboard;
     if (!keyboard || gameplayInputBlocked === this.gameplayCaptureDisabled) {
@@ -327,6 +405,7 @@ export class OverworldScene extends Phaser.Scene {
     }
 
     this.sceneDefinition = location.scene;
+    this.fieldMonsters = this.fieldMonsters.filter((monster) => monster.sceneId === location.scene.sceneId);
     this.cameras.main.setBackgroundColor(location.scene.backgroundColor);
 
     this.children.removeAll(true);
@@ -336,8 +415,11 @@ export class OverworldScene extends Phaser.Scene {
     this.npcMarkers = [];
     this.lastPromptKey = "";
     this.lastBroadcastKey = "";
+    this.lastFieldMonsterContactId = "";
     this.remoteSprites.forEach((remote) => remote.container.destroy());
     this.remoteSprites.clear();
+    this.fieldMonsterSprites.forEach((monster) => monster.container.destroy());
+    this.fieldMonsterSprites.clear();
 
     this.renderSceneMap(location.scene);
 
@@ -487,6 +569,7 @@ export class OverworldScene extends Phaser.Scene {
       )
       .setDisplaySize(32, 32)
       .setDepth(8);
+    this.syncFieldMonsterSprites(this.fieldMonsters);
     this.hintText = this.createReadableLabel(
       this.playerState.position.x,
       this.playerState.position.y - 34,
@@ -527,8 +610,14 @@ export class OverworldScene extends Phaser.Scene {
     return this.npcMarkers.find(({ sprite }) => Phaser.Math.Distance.Between(sprite.x, sprite.y, x, y) < 64) ?? null;
   }
 
-  private findActiveEncounter(x: number, y: number): { zone: Phaser.Geom.Rectangle; data: EncounterZone } | null {
-    return this.encounterZones.find(({ zone }) => Phaser.Geom.Rectangle.Contains(zone, x, y)) ?? null;
+  private findActiveFieldMonster(x: number, y: number): FieldMonsterState | null {
+    return this.fieldMonsters.find((monster) => {
+      if (monster.inBattleBy) {
+        return false;
+      }
+      const contactDistance = monster.isBoss ? BOSS_CONTACT_DISTANCE : MONSTER_CONTACT_DISTANCE;
+      return Phaser.Math.Distance.Between(monster.x, monster.y, x, y) <= contactDistance;
+    }) ?? null;
   }
 
   private resolvePrompt(params: {
@@ -536,7 +625,6 @@ export class OverworldScene extends Phaser.Scene {
     hasPendingLocationStory: boolean;
     portal: { label: string } | null;
     npc: DialogueNpc | null;
-    encounter: EncounterZone | null;
   }): FieldPrompt {
     if (params.overlayMode === "battle") {
       return {
@@ -578,16 +666,6 @@ export class OverworldScene extends Phaser.Scene {
       };
     }
 
-    if (params.encounter) {
-      return {
-        kind: "encounter",
-        title: "적 조우 가능 구역",
-        body: "B 키를 눌러 현재 지역 적과 교전할 수 있습니다.",
-        actionLabel: "B",
-        tone: "danger",
-      };
-    }
-
     if (params.hasPendingLocationStory) {
       return {
         kind: "story",
@@ -601,8 +679,8 @@ export class OverworldScene extends Phaser.Scene {
     return {
       kind: "idle",
       title: this.sceneDefinition?.sceneId ?? "오버월드 탐험",
-      body: "WASD 이동, Enter 씬 전환, Space 대화, B 전투로 현재 지역을 탐험하세요.",
-      actionLabel: "WASD / Space / Enter / B",
+      body: "WASD 이동, Enter 씬 전환, Space 대화로 현재 지역을 탐험하세요.",
+      actionLabel: "WASD / Space / Enter",
       tone: "neutral",
     };
   }
@@ -651,8 +729,6 @@ export class OverworldScene extends Phaser.Scene {
         return `${prompt.title.replace(/ 준비$/, "")}하려면 ${prompt.actionLabel} 누르기`;
       case "npc":
         return `${prompt.title}하려면 ${prompt.actionLabel} 누르기`;
-      case "encounter":
-        return `전투하려면 ${prompt.actionLabel} 누르기`;
       case "story":
         return `이야기 보려면 ${prompt.actionLabel} 누르기`;
       default:

--- a/apps/web/src/net/socket.ts
+++ b/apps/web/src/net/socket.ts
@@ -1,5 +1,11 @@
 import { io, type Socket } from "socket.io-client";
-import type { ChatMessage, Facing, PresenceState } from "@rpg/game-core";
+import type {
+  ChatMessage,
+  Facing,
+  FieldMonsterClaimResult,
+  FieldMonsterState,
+  PresenceState,
+} from "@rpg/game-core";
 
 type PresenceIntent = {
   sceneId: string;
@@ -15,6 +21,8 @@ type RealtimeHandlers = {
   onPresenceUpdate: (presence: PresenceState) => void;
   onPresenceLeft: (username: string) => void;
   onChatMessage: (message: ChatMessage) => void;
+  onFieldMonstersSnapshot: (snapshot: FieldMonsterState[]) => void;
+  onFieldMonstersUpdate: (snapshot: FieldMonsterState[]) => void;
   onConnect: () => void;
   onDisconnect: (reason: string) => void;
   onConnectError: (message: string) => void;
@@ -58,6 +66,8 @@ export class PresenceClient {
     this.socket.on("presence:update", this.handlers.onPresenceUpdate);
     this.socket.on("presence:left", this.handlers.onPresenceLeft);
     this.socket.on("chat:message", this.handlers.onChatMessage);
+    this.socket.on("field-monsters:snapshot", this.handlers.onFieldMonstersSnapshot);
+    this.socket.on("field-monsters:update", this.handlers.onFieldMonstersUpdate);
   }
 
   disconnect(): void {
@@ -98,6 +108,38 @@ export class PresenceClient {
   sendChat(text: string): void {
     if (this.isConnected) {
       this.socket?.emit("chat:send", { text });
+    }
+  }
+
+  claimFieldMonster(monsterId: string): Promise<FieldMonsterClaimResult> {
+    if (!this.isConnected || !this.socket) {
+      return Promise.resolve({ ok: false, reason: "offline" });
+    }
+
+    return new Promise((resolve) => {
+      let settled = false;
+      const timer = globalThis.setTimeout(() => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        resolve({ ok: false, reason: "offline" });
+      }, 1500);
+
+      this.socket?.emit("field-monsters:claim", { monsterId }, (result: FieldMonsterClaimResult) => {
+        if (settled) {
+          return;
+        }
+        globalThis.clearTimeout(timer);
+        settled = true;
+        resolve(result);
+      });
+    });
+  }
+
+  releaseFieldMonster(monsterId: string): void {
+    if (this.isConnected) {
+      this.socket?.emit("field-monsters:release", { monsterId });
     }
   }
 

--- a/apps/web/src/state/store.ts
+++ b/apps/web/src/state/store.ts
@@ -1,4 +1,11 @@
-import type { BattleState, ChatMessage, PlayerSave, PresenceState, WorldContent } from "@rpg/game-core";
+import type {
+  BattleState,
+  ChatMessage,
+  FieldMonsterState,
+  PlayerSave,
+  PresenceState,
+  WorldContent,
+} from "@rpg/game-core";
 import type { BattleReport, FieldPrompt } from "../gameplay";
 
 export type DialogueState = {
@@ -16,6 +23,7 @@ export type AppState = {
   battle: BattleState | null;
   battleReport: BattleReport | null;
   presence: PresenceState[];
+  fieldMonsters: FieldMonsterState[];
   chatMessages: ChatMessage[];
   dialogue: DialogueState | null;
   fieldPrompt: FieldPrompt | null;
@@ -35,6 +43,7 @@ export class AppStore {
     battle: null,
     battleReport: null,
     presence: [],
+    fieldMonsters: [],
     chatMessages: [],
     dialogue: null,
     fieldPrompt: null,

--- a/apps/web/test/presenceClient.test.ts
+++ b/apps/web/test/presenceClient.test.ts
@@ -45,6 +45,8 @@ describe("PresenceClient", () => {
         onPresenceUpdate: vi.fn(),
         onPresenceLeft: vi.fn(),
         onChatMessage: vi.fn(),
+        onFieldMonstersSnapshot: vi.fn(),
+        onFieldMonstersUpdate: vi.fn(),
         onConnect,
         onDisconnect,
         onConnectError: vi.fn(),

--- a/packages/game-core/src/content/legacy.ts
+++ b/packages/game-core/src/content/legacy.ts
@@ -500,6 +500,9 @@ export function buildWorldContentFromLegacy(input: {
           id,
           name: enemy.이름,
           texturePath: getEnemyTexturePath({ name: enemy.이름, mainLocation, subLocation }),
+          spawnRate: typeof enemy.spawn_rate === "number" && Number.isFinite(enemy.spawn_rate) && enemy.spawn_rate > 0
+            ? enemy.spawn_rate
+            : 1,
           maxHp: enemy.체력,
           attack: enemy.공격력,
           defense: enemy.방어력,

--- a/packages/game-core/src/types.ts
+++ b/packages/game-core/src/types.ts
@@ -84,6 +84,7 @@ export type EnemyDefinition = {
   id: string;
   name: string;
   texturePath: string;
+  spawnRate?: number;
   currentHp?: number;
   maxHp: number;
   attack: number;
@@ -256,6 +257,23 @@ export type ChatMessage = {
   createdAt: string;
 };
 
+export type FieldMonsterState = {
+  id: string;
+  sceneId: string;
+  enemyId: string;
+  enemyName: string;
+  texturePath: string;
+  x: number;
+  y: number;
+  isBoss: boolean;
+  inBattleBy?: string;
+  spawnedAt: string;
+};
+
+export type FieldMonsterClaimResult =
+  | { ok: true; monster: FieldMonsterState }
+  | { ok: false; reason: "busy" | "invalid_scene" | "not_found" | "offline" };
+
 export type WorldContent = {
   startLocationKey: string;
   locations: Record<string, LocationNode>;
@@ -340,6 +358,7 @@ export type LegacyEquipmentData = Array<{
 
 export type LegacyEnemyUnit = {
   이름: string;
+  spawn_rate?: number;
   체력: number;
   공격력: number;
   경험치: number;

--- a/packages/game-core/src/validation.ts
+++ b/packages/game-core/src/validation.ts
@@ -188,6 +188,10 @@ function validateEnemy(enemy: EnemyDefinition, path: string): ValidationIssue[] 
     issues.push(issue(`${path}.maxHp`, "Enemy maxHp must be greater than 0."));
   }
 
+  if (enemy.spawnRate !== undefined && (!Number.isFinite(enemy.spawnRate) || enemy.spawnRate <= 0)) {
+    issues.push(issue(`${path}.spawnRate`, "Enemy spawnRate must be a positive finite number."));
+  }
+
   if (!VALID_ENEMY_TEXTURES.has(enemy.texturePath)) {
     issues.push(issue(`${path}.texturePath`, "Enemy texture path is outside the shared monster asset set."));
   }

--- a/packages/game-core/test/content.test.ts
+++ b/packages/game-core/test/content.test.ts
@@ -5,7 +5,13 @@ import boss from "../../../game/boss.json";
 import equipment from "../../../game/equipment.json";
 import skill from "../../../game/skill.json";
 import tactics from "../../../game/tactics.json";
-import { buildWorldContentFromLegacy, createSceneLayout, createScenePortalSlots, validateWorldContent } from "../src";
+import {
+  buildWorldContentFromLegacy,
+  createSceneLayout,
+  createScenePortalSlots,
+  validateWorldContent,
+  type LegacyMonsterData,
+} from "../src";
 
 function rectanglesOverlap(
   left: { x: number; y: number; width: number; height: number },
@@ -92,6 +98,27 @@ describe("legacy content conversion", () => {
     });
 
     expect(issues.some((entry) => entry.path.endsWith("assets.mapJsonPath"))).toBe(true);
+  });
+
+  it("maps optional monster spawn_rate values into shared spawn weights", () => {
+    const monstersWithRates = structuredClone(monster) as LegacyMonsterData;
+    const firstMonster = Object.values(monstersWithRates)
+      .flatMap((subLocations) => Object.values(subLocations))
+      .find((enemies) => enemies.length > 0)?.[0];
+    expect(firstMonster).toBeTruthy();
+    firstMonster!.spawn_rate = 7;
+
+    const world = buildWorldContentFromLegacy({
+      map,
+      monsters: monstersWithRates,
+      bosses: boss,
+      equipment: equipment as never,
+      skills: skill as never,
+      tactics: tactics as never,
+    });
+
+    const convertedEnemy = Object.values(world.enemies).find((enemy) => enemy.name === firstMonster!.이름 && enemy.spawnRate === 7);
+    expect(convertedEnemy?.spawnRate).toBe(7);
   });
 
   it("creates non-overlapping portal slots when a layout needs more than four exits", () => {


### PR DESCRIPTION
## Summary
- 서버 권위 필드 몬스터 스폰/선점/해제 흐름을 추가했습니다.
- 몬스터존 필드에 일반 몬스터를 최대 20마리까지 채우고, spawn_rate 기반 상대 확률로 배치합니다.
- 보스는 일반 배치 수와 별개로 항상 사용 가능한 1마리를 유지하며, 전투 종료 시 해당 인스턴스를 제거합니다.
- 클라이언트 오버월드에서 B키 조우 대신 몬스터 스프라이트 접촉으로 전투를 시작합니다.

## Verification
- corepack pnpm --filter @rpg/game-core typecheck
- corepack pnpm --filter @rpg/server typecheck
- corepack pnpm --filter @rpg/web typecheck
- corepack pnpm --filter @rpg/game-core test
- corepack pnpm --filter @rpg/server test
- corepack pnpm --filter @rpg/web test
- corepack pnpm -r lint
- corepack pnpm -r build
- git diff --check