### PR TITLE
Smooth field interaction and zone monster spawning

### DIFF
--- a/apps/server/src/realtime/fieldMonsters.ts
+++ b/apps/server/src/realtime/fieldMonsters.ts
@@ -7,6 +7,7 @@ import type {
 } from "@rpg/game-core";
 
 const MAX_NORMAL_MONSTERS_PER_SCENE = 20;
+const MAX_NORMAL_MONSTERS_PER_ZONE = 5;
 const MONSTER_HITBOX_SIZE = 36;
 const MONSTER_SPACING = 44;
 const BLOCKING_BUFFER = 28;
@@ -21,6 +22,7 @@ type Rectangle = {
 type SceneSpawnConfig = {
   scene: SceneDefinition;
   normalEnemyIds: string[];
+  normalZones: EncounterZone[];
   bossEnemyId?: string;
 };
 
@@ -160,16 +162,15 @@ export class FieldMonsterManager {
   private buildSceneConfigs(): void {
     Object.values(this.world.locations).forEach((location) => {
       const scene = location.scene;
-      if (scene.encounterZones.length === 0) {
-        return;
-      }
-
       const encounterEnemyIds = Array.from(new Set(scene.encounterZones.flatMap((zone) => zone.enemyIds)));
       const normalEnemyIds = encounterEnemyIds.filter((enemyId) => {
         const enemy = this.world.enemies[enemyId];
         return Boolean(enemy && !enemy.isBoss);
       });
-      const bossEnemyId = encounterEnemyIds.find((enemyId) => Boolean(this.world.enemies[enemyId]?.isBoss));
+      const normalZones = scene.encounterZones.filter((zone) =>
+        zone.enemyIds.some((enemyId) => normalEnemyIds.includes(enemyId)),
+      );
+      const bossEnemyId = this.findBossEnemyId(location.bossName, encounterEnemyIds);
       if (normalEnemyIds.length === 0 && !bossEnemyId) {
         return;
       }
@@ -177,10 +178,22 @@ export class FieldMonsterManager {
       this.sceneConfigs.set(scene.sceneId, {
         scene,
         normalEnemyIds,
+        normalZones,
         bossEnemyId,
       });
       this.monstersByScene.set(scene.sceneId, []);
     });
+  }
+
+  private findBossEnemyId(bossName: string | undefined, encounterEnemyIds: string[]): string | undefined {
+    const encounterBossId = encounterEnemyIds.find((enemyId) => Boolean(this.world.enemies[enemyId]?.isBoss));
+    if (encounterBossId) {
+      return encounterBossId;
+    }
+    if (!bossName) {
+      return undefined;
+    }
+    return Object.values(this.world.enemies).find((enemy) => enemy.isBoss && enemy.name === bossName)?.id;
   }
 
   private refillScene(sceneId: string, options: RefillOptions): boolean {
@@ -192,13 +205,18 @@ export class FieldMonsterManager {
 
     let changed = false;
     if (options.fillNormal) {
-      while (monsters.filter((monster) => !monster.isBoss).length < MAX_NORMAL_MONSTERS_PER_SCENE) {
-        const spawned = this.spawnNormalMonster(config, monsters);
-        if (!spawned) {
-          break;
+      for (const zone of config.normalZones) {
+        while (
+          monsters.filter((monster) => !monster.isBoss && monster.zoneId === zone.id).length < MAX_NORMAL_MONSTERS_PER_ZONE
+          && monsters.filter((monster) => !monster.isBoss).length < MAX_NORMAL_MONSTERS_PER_SCENE
+        ) {
+          const spawned = this.spawnNormalMonster(config, zone, monsters);
+          if (!spawned) {
+            break;
+          }
+          monsters.push(spawned);
+          changed = true;
         }
-        monsters.push(spawned);
-        changed = true;
       }
     }
 
@@ -209,13 +227,18 @@ export class FieldMonsterManager {
     return changed;
   }
 
-  private spawnNormalMonster(config: SceneSpawnConfig, existingMonsters: FieldMonsterState[]): FieldMonsterState | null {
+  private spawnNormalMonster(
+    config: SceneSpawnConfig,
+    zone: EncounterZone,
+    existingMonsters: FieldMonsterState[],
+  ): FieldMonsterState | null {
     if (config.normalEnemyIds.length === 0) {
       return null;
     }
 
-    const enemyId = this.pickWeightedEnemy(config.normalEnemyIds);
-    return this.createMonster(config, enemyId, false, existingMonsters);
+    const zoneEnemyIds = zone.enemyIds.filter((enemyId) => config.normalEnemyIds.includes(enemyId));
+    const enemyId = this.pickWeightedEnemy(zoneEnemyIds.length > 0 ? zoneEnemyIds : config.normalEnemyIds);
+    return this.createMonster(config, enemyId, false, existingMonsters, [zone], zone.id);
   }
 
   private ensureAvailableBoss(config: SceneSpawnConfig, existingMonsters: FieldMonsterState[]): boolean {
@@ -228,7 +251,13 @@ export class FieldMonsterManager {
       return false;
     }
 
-    const boss = this.createMonster(config, config.bossEnemyId, true, existingMonsters);
+    const boss = this.createMonster(
+      config,
+      config.bossEnemyId,
+      true,
+      existingMonsters,
+      this.getZonesForEnemy(config.scene, config.bossEnemyId),
+    );
     if (!boss) {
       return false;
     }
@@ -241,14 +270,15 @@ export class FieldMonsterManager {
     enemyId: string,
     isBoss: boolean,
     existingMonsters: FieldMonsterState[],
+    zones: EncounterZone[],
+    zoneId?: string,
   ): FieldMonsterState | null {
     const enemy = this.world.enemies[enemyId];
     if (!enemy) {
       return null;
     }
 
-    const zones = this.getZonesForEnemy(config.scene, enemyId);
-    const position = this.pickSpawnPosition(config.scene, zones, existingMonsters);
+    const position = this.pickSpawnPosition(config.scene, this.getSpawnZones(config.scene, zones, enemyId), existingMonsters);
     if (!position) {
       return null;
     }
@@ -261,6 +291,7 @@ export class FieldMonsterManager {
       texturePath: enemy.texturePath,
       x: Math.round(position.x),
       y: Math.round(position.y),
+      zoneId,
       isBoss,
       spawnedAt: new Date().toISOString(),
     };
@@ -286,6 +317,24 @@ export class FieldMonsterManager {
   private getZonesForEnemy(scene: SceneDefinition, enemyId: string): EncounterZone[] {
     const matchingZones = scene.encounterZones.filter((zone) => zone.enemyIds.includes(enemyId));
     return matchingZones.length > 0 ? matchingZones : scene.encounterZones;
+  }
+
+  private getSpawnZones(scene: SceneDefinition, zones: EncounterZone[], enemyId: string): EncounterZone[] {
+    if (zones.length > 0) {
+      return zones;
+    }
+
+    const margin = Math.max(72, MONSTER_HITBOX_SIZE + BLOCKING_BUFFER);
+    return [
+      {
+        id: `${scene.sceneId}-free-spawn`,
+        x: margin,
+        y: margin,
+        width: Math.max(MONSTER_HITBOX_SIZE, scene.width - margin * 2),
+        height: Math.max(MONSTER_HITBOX_SIZE, scene.height - margin * 2),
+        enemyIds: [enemyId],
+      },
+    ];
   }
 
   private pickSpawnPosition(

--- a/apps/server/test/realtime.test.ts
+++ b/apps/server/test/realtime.test.ts
@@ -99,16 +99,42 @@ function createFieldMonsterWorld(options: { boss?: boolean } = {}): WorldContent
               lines: ["Stay alert."],
             },
           ],
-          encounterZones: [
-            {
-              id: "encounter-field",
-              x: 180,
-              y: 170,
-              width: 560,
-              height: 420,
-              enemyIds,
-            },
-          ],
+          encounterZones: options.boss
+            ? []
+            : [
+                {
+                  id: "encounter-field-1",
+                  x: 180,
+                  y: 170,
+                  width: 180,
+                  height: 120,
+                  enemyIds,
+                },
+                {
+                  id: "encounter-field-2",
+                  x: 560,
+                  y: 170,
+                  width: 180,
+                  height: 120,
+                  enemyIds,
+                },
+                {
+                  id: "encounter-field-3",
+                  x: 180,
+                  y: 470,
+                  width: 180,
+                  height: 120,
+                  enemyIds,
+                },
+                {
+                  id: "encounter-field-4",
+                  x: 560,
+                  y: 470,
+                  width: 180,
+                  height: 120,
+                  enemyIds,
+                },
+              ],
           collisionZones: [],
           assets: {
             layoutId: options.boss ? "boss_arena" : "field",
@@ -590,6 +616,9 @@ describe("realtime presence", () => {
 
       expect(normalMonsters).toHaveLength(20);
       expect(normalMonsters.every((monster) => monster.sceneId === "scene-field")).toBe(true);
+      ["encounter-field-1", "encounter-field-2", "encounter-field-3", "encounter-field-4"].forEach((zoneId) => {
+        expect(normalMonsters.filter((monster) => monster.zoneId === zoneId)).toHaveLength(5);
+      });
       const location = world.locations[world.startLocationKey]!;
       const portal = location.scene.portals[0]!;
       const npcBlock = { x: 816, y: 208, width: 48, height: 64 };
@@ -667,6 +696,7 @@ describe("realtime presence", () => {
       socketA.emit("presence:join", { sceneId: "scene-field", x: 72, y: 72, facing: "down", avatarId: DEFAULT_PLAYER_AVATAR_ID });
       const initialBosses = await snapshotA;
       expect(initialBosses.filter((monster) => monster.isBoss)).toHaveLength(1);
+      expect(initialBosses.every((monster) => monster.zoneId === undefined)).toBe(true);
 
       const snapshotB = onceEvent<FieldMonsterState[]>(socketB, "field-monsters:snapshot");
       socketB.emit("presence:join", { sceneId: "scene-field", x: 90, y: 72, facing: "down", avatarId: DEFAULT_PLAYER_AVATAR_ID });

--- a/apps/web/src/AppController.ts
+++ b/apps/web/src/AppController.ts
@@ -511,7 +511,8 @@ export class AppController {
     }
 
     this.store.pushLog(`${state.dialogue.title} 대화 종료`);
-    if (result.completedLocationStory) {
+    result.rewardMessages.forEach((message) => this.store.pushLog(message));
+    if (result.completedLocationStory || result.rewardMessages.length > 0) {
       await this.savePlayer();
     }
   }

--- a/apps/web/src/game/OverworldScene.ts
+++ b/apps/web/src/game/OverworldScene.ts
@@ -68,6 +68,8 @@ type FieldMonsterSprite = {
   sprite: Phaser.GameObjects.Sprite;
   label: Phaser.GameObjects.Text;
   texturePath: string;
+  zoneId?: string;
+  wanderTween?: Phaser.Tweens.Tween;
 };
 
 type DeathGraveSprite = {
@@ -77,6 +79,7 @@ type DeathGraveSprite = {
 
 const REMOTE_INTERPOLATION_SPEED = 12;
 const REMOTE_SNAP_DISTANCE = 240;
+const LOCAL_PLAYER_SYNC_SNAP_DISTANCE = 96;
 const MONSTER_CONTACT_DISTANCE = 42;
 const BOSS_CONTACT_DISTANCE = 58;
 const GRAVE_INTERACTION_DISTANCE = 58;
@@ -155,16 +158,34 @@ export class OverworldScene extends Phaser.Scene {
     fieldMonsters: FieldMonsterState[],
     deathGraves: DeathGraveState[],
   ): void {
-    this.playerState = player;
+    const previousSceneId = this.sceneDefinition?.sceneId;
     const location = this.world?.locations[player.locationKey];
-    if (location && location.scene.sceneId !== this.sceneDefinition?.sceneId) {
+    if (location && location.scene.sceneId !== previousSceneId) {
+      this.playerState = player;
       this.buildLocation();
     }
     this.fieldMonsters = fieldMonsters.filter((monster) => monster.sceneId === this.sceneDefinition?.sceneId);
     this.deathGraves = deathGraves.filter((grave) => grave.sceneId === this.sceneDefinition?.sceneId);
 
     if (this.playerSprite) {
-      this.playerSprite.setPosition(player.position.x, player.position.y);
+      const syncDistance = Phaser.Math.Distance.Between(
+        this.playerSprite.x,
+        this.playerSprite.y,
+        player.position.x,
+        player.position.y,
+      );
+      if (syncDistance > LOCAL_PLAYER_SYNC_SNAP_DISTANCE || location?.scene.sceneId !== previousSceneId) {
+        this.playerSprite.setPosition(player.position.x, player.position.y);
+      }
+      this.playerState = {
+        ...player,
+        position: {
+          x: this.playerSprite.x,
+          y: this.playerSprite.y,
+        },
+      };
+    } else {
+      this.playerState = player;
     }
     this.syncFieldMonsterSprites(this.fieldMonsters);
     this.syncDeathGraveSprites(this.deathGraves);
@@ -358,12 +379,19 @@ export class OverworldScene extends Phaser.Scene {
       activeIds.add(monster.id);
       const existing = this.fieldMonsterSprites.get(monster.id);
       if (existing) {
-        existing.container.setPosition(monster.x, monster.y);
         existing.container.setAlpha(monster.inBattleBy ? 0.42 : 1);
         existing.label.setText(monster.inBattleBy ? `${monster.enemyName} (전투 중)` : monster.enemyName);
         if (existing.texturePath !== monster.texturePath) {
           existing.sprite.setTexture(monster.texturePath);
           existing.texturePath = monster.texturePath;
+        }
+        if (monster.inBattleBy) {
+          existing.wanderTween?.stop();
+          existing.wanderTween = undefined;
+        } else if (existing.zoneId !== monster.zoneId || !existing.wanderTween) {
+          existing.wanderTween?.stop();
+          existing.zoneId = monster.zoneId;
+          this.startMonsterWander(monster, existing);
         }
         return;
       }
@@ -392,15 +420,56 @@ export class OverworldScene extends Phaser.Scene {
         sprite,
         label,
         texturePath: monster.texturePath,
+        zoneId: monster.zoneId,
       });
+      this.startMonsterWander(monster, this.fieldMonsterSprites.get(monster.id)!);
     });
 
     Array.from(this.fieldMonsterSprites.entries()).forEach(([monsterId, rendered]) => {
       if (!activeIds.has(monsterId)) {
+        rendered.wanderTween?.stop();
         rendered.container.destroy();
         this.fieldMonsterSprites.delete(monsterId);
       }
     });
+  }
+
+  private startMonsterWander(monster: FieldMonsterState, rendered: FieldMonsterSprite): void {
+    if (monster.isBoss || monster.inBattleBy || !monster.zoneId) {
+      return;
+    }
+
+    const zone = this.sceneDefinition?.encounterZones.find((candidate) => candidate.id === monster.zoneId);
+    if (!zone) {
+      return;
+    }
+
+    const target = this.pickPointInZone(zone, 24);
+    rendered.wanderTween = this.tweens.add({
+      targets: rendered.container,
+      x: target.x,
+      y: target.y,
+      duration: Phaser.Math.Between(2600, 5200),
+      ease: "sine.inOut",
+      onComplete: () => {
+        rendered.wanderTween = undefined;
+        const latestMonster = this.fieldMonsters.find((candidate) => candidate.id === monster.id);
+        if (latestMonster) {
+          this.startMonsterWander(latestMonster, rendered);
+        }
+      },
+    });
+  }
+
+  private pickPointInZone(zone: EncounterZone, padding: number): { x: number; y: number } {
+    const minX = zone.x + padding;
+    const maxX = zone.x + zone.width - padding;
+    const minY = zone.y + padding;
+    const maxY = zone.y + zone.height - padding;
+    return {
+      x: Phaser.Math.Between(Math.round(Math.min(minX, maxX)), Math.round(Math.max(minX, maxX))),
+      y: Phaser.Math.Between(Math.round(Math.min(minY, maxY)), Math.round(Math.max(minY, maxY))),
+    };
   }
 
   private syncDeathGraveSprites(graves: DeathGraveState[]): void {
@@ -484,7 +553,10 @@ export class OverworldScene extends Phaser.Scene {
     this.lastFieldMonsterContactId = "";
     this.remoteSprites.forEach((remote) => remote.container.destroy());
     this.remoteSprites.clear();
-    this.fieldMonsterSprites.forEach((monster) => monster.container.destroy());
+    this.fieldMonsterSprites.forEach((monster) => {
+      monster.wanderTween?.stop();
+      monster.container.destroy();
+    });
     this.fieldMonsterSprites.clear();
     this.deathGraveSprites.forEach((grave) => grave.container.destroy());
     this.deathGraveSprites.clear();
@@ -573,34 +645,15 @@ export class OverworldScene extends Phaser.Scene {
           location.scene.assets.encounterTexturePath,
         )
         .setDisplaySize(zoneDisplayWidth, zoneDisplayHeight)
-        .setAlpha(0.3)
+        .setAlpha(0.22)
         .setDepth(2);
-      const encounterGlow = this.add
+      this.add
         .image(zoneCenterX, zoneCenterY, location.scene.assets.encounterTexturePath)
-        .setDisplaySize(zoneDisplayWidth * 0.86, zoneDisplayHeight * 0.82)
-        .setAlpha(0.12)
+        .setDisplaySize(zoneDisplayWidth * 0.72, zoneDisplayHeight * 0.68)
+        .setAlpha(0.08)
         .setDepth(3)
         .setBlendMode(Phaser.BlendModes.ADD);
-      this.tweens.add({
-        targets: encounterMarker,
-        alpha: 0.42,
-        scaleX: 1.01,
-        scaleY: 1.018,
-        duration: 1500,
-        yoyo: true,
-        repeat: -1,
-        ease: "sine.inOut",
-      });
-      this.tweens.add({
-        targets: encounterGlow,
-        alpha: 0.24,
-        scaleX: 1.045,
-        scaleY: 1.06,
-        duration: 1180,
-        yoyo: true,
-        repeat: -1,
-        ease: "sine.inOut",
-      });
+      encounterMarker.setTint(0xc6f6d5);
       this.encounterZones.push({
         zone: new Phaser.Geom.Rectangle(encounterZone.x, encounterZone.y, encounterZone.width, encounterZone.height),
         data: encounterZone,
@@ -691,7 +744,10 @@ export class OverworldScene extends Phaser.Scene {
         return false;
       }
       const contactDistance = monster.isBoss ? BOSS_CONTACT_DISTANCE : MONSTER_CONTACT_DISTANCE;
-      return Phaser.Math.Distance.Between(monster.x, monster.y, x, y) <= contactDistance;
+      const rendered = this.fieldMonsterSprites.get(monster.id);
+      const monsterX = rendered?.container.x ?? monster.x;
+      const monsterY = rendered?.container.y ?? monster.y;
+      return Phaser.Math.Distance.Between(monsterX, monsterY, x, y) <= contactDistance;
     }) ?? null;
   }
 

--- a/apps/web/src/story.ts
+++ b/apps/web/src/story.ts
@@ -1,5 +1,16 @@
-import { ensureStoryState, type LocationNode, type PlayerSave } from "@rpg/game-core";
+import { ensureStoryState, toLocationKey, toStableId, type LocationNode, type PlayerSave } from "@rpg/game-core";
 import type { DialogueState } from "./state/store";
+
+const BLACKSMITH_REWARD_LOCATION_KEY = toLocationKey("시작의 마을", "무기 상점");
+const BLACKSMITH_REWARD_EQUIPMENT_ID = toStableId("equipment", "마을의 검");
+const BLACKSMITH_REWARD_MESSAGE = "대장장이가 '마을의 검'을 지급하였습니다.";
+
+type DialogueAdvanceResult = {
+  player: PlayerSave;
+  dialogue: DialogueState | null;
+  completedLocationStory: boolean;
+  rewardMessages: string[];
+};
 
 export function hasUnreadLocationStory(
   player: PlayerSave | null,
@@ -56,7 +67,7 @@ export function createLocationStoryDialogue(
 export function advanceDialogueProgress(
   player: PlayerSave,
   dialogue: DialogueState,
-): { player: PlayerSave; dialogue: DialogueState | null; completedLocationStory: boolean } {
+): DialogueAdvanceResult {
   const lastIndex = dialogue.lines.length - 1;
   if (dialogue.index < lastIndex) {
     return {
@@ -66,29 +77,57 @@ export function advanceDialogueProgress(
         index: dialogue.index + 1,
       },
       completedLocationStory: false,
+      rewardMessages: [],
     };
   }
 
   if (dialogue.kind !== "location") {
+    const rewarded = applyDialogueCompletionRewards(player, dialogue);
     return {
-      player,
+      player: rewarded.player,
       dialogue: null,
       completedLocationStory: false,
+      rewardMessages: rewarded.messages,
     };
+  }
+
+  const completedPlayer: PlayerSave = {
+    ...player,
+    storyState: {
+      ...player.storyState,
+      [dialogue.locationKey]: {
+        completed: true,
+        currentIndex: Math.max(0, lastIndex),
+      },
+    },
+  };
+  const rewarded = applyDialogueCompletionRewards(completedPlayer, dialogue);
+
+  return {
+    player: rewarded.player,
+    dialogue: null,
+    completedLocationStory: true,
+    rewardMessages: rewarded.messages,
+  };
+}
+
+function applyDialogueCompletionRewards(
+  player: PlayerSave,
+  dialogue: DialogueState,
+): { player: PlayerSave; messages: string[] } {
+  if (dialogue.locationKey !== BLACKSMITH_REWARD_LOCATION_KEY) {
+    return { player, messages: [] };
+  }
+
+  if (player.ownedEquipmentIds.includes(BLACKSMITH_REWARD_EQUIPMENT_ID)) {
+    return { player, messages: [] };
   }
 
   return {
     player: {
       ...player,
-      storyState: {
-        ...player.storyState,
-        [dialogue.locationKey]: {
-          completed: true,
-          currentIndex: Math.max(0, lastIndex),
-        },
-      },
+      ownedEquipmentIds: [...player.ownedEquipmentIds, BLACKSMITH_REWARD_EQUIPMENT_ID],
     },
-    dialogue: null,
-    completedLocationStory: true,
+    messages: [BLACKSMITH_REWARD_MESSAGE],
   };
 }

--- a/apps/web/test/story.test.ts
+++ b/apps/web/test/story.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createStarterPlayer, type LocationNode, type WorldContent } from "@rpg/game-core";
+import { createStarterPlayer, toLocationKey, toStableId, type LocationNode, type WorldContent } from "@rpg/game-core";
 import {
   advanceDialogueProgress,
   createLocationStoryDialogue,
@@ -88,5 +88,32 @@ describe("location story helpers", () => {
     });
     expect(npcAdvanced.completedLocationStory).toBe(false);
     expect(npcAdvanced.player.storyState[baseLocation.key]?.completed).toBe(false);
+  });
+
+  it("adds the starter sword when the starting blacksmith dialogue ends", () => {
+    const blacksmithLocationKey = toLocationKey("시작의 마을", "무기 상점");
+    const starterSwordId = toStableId("equipment", "마을의 검");
+    const player = {
+      ...createStarterPlayer("tester", baseWorld),
+      locationKey: blacksmithLocationKey,
+      storyState: {
+        ...createStarterPlayer("tester", baseWorld).storyState,
+        [blacksmithLocationKey]: {
+          completed: false,
+          currentIndex: 0,
+        },
+      },
+    };
+
+    const advanced = advanceDialogueProgress(player, {
+      kind: "npc",
+      title: "대장장이",
+      locationKey: blacksmithLocationKey,
+      lines: ["마을의 검을 주지."],
+      index: 0,
+    });
+
+    expect(advanced.player.ownedEquipmentIds).toContain(starterSwordId);
+    expect(advanced.rewardMessages).toEqual(["대장장이가 '마을의 검'을 지급하였습니다."]);
   });
 });

--- a/packages/game-core/src/content/legacy.ts
+++ b/packages/game-core/src/content/legacy.ts
@@ -1,5 +1,6 @@
 import type {
   EffectDefinition,
+  EncounterZone,
   EquipmentDefinition,
   LegacyBossData,
   LegacyEquipmentData,
@@ -322,6 +323,43 @@ function areaColor(mainLocation: string): string {
   return colors[mainLocation] ?? "#34506b";
 }
 
+function buildEncounterZones(
+  sceneId: string,
+  layout: { width: number; height: number; encounterZone: { x: number; y: number; width: number; height: number } },
+  enemyIds: string[],
+): EncounterZone[] {
+  if (enemyIds.length === 0) {
+    return [];
+  }
+
+  const base = layout.encounterZone;
+  const zoneWidth = Math.min(190, Math.max(128, Math.round(base.width * 0.46)));
+  const zoneHeight = Math.min(118, Math.max(88, Math.round(base.height * 0.5)));
+  const centerX = base.x + base.width / 2;
+  const centerY = base.y + base.height / 2;
+  const offsetX = Math.max(zoneWidth / 2 + 12, Math.round(base.width * 0.26));
+  const offsetY = Math.max(zoneHeight / 2 + 10, Math.round(base.height * 0.28));
+  const clamp = (value: number, min: number, max: number): number => Math.min(max, Math.max(min, value));
+  const minX = zoneWidth / 2 + 52;
+  const maxX = layout.width - zoneWidth / 2 - 52;
+  const minY = zoneHeight / 2 + 72;
+  const maxY = layout.height - zoneHeight / 2 - 72;
+
+  return [
+    { x: centerX - offsetX, y: centerY - offsetY },
+    { x: centerX + offsetX, y: centerY - offsetY },
+    { x: centerX - offsetX, y: centerY + offsetY },
+    { x: centerX + offsetX, y: centerY + offsetY },
+  ].map((center, index) => ({
+    id: toStableId("encounter", `${sceneId}-${index + 1}`),
+    x: Math.round(clamp(center.x, minX, maxX) - zoneWidth / 2),
+    y: Math.round(clamp(center.y, minY, maxY) - zoneHeight / 2),
+    width: zoneWidth,
+    height: zoneHeight,
+    enemyIds,
+  }));
+}
+
 function buildScene(
   mainLocation: string,
   subLocation: string,
@@ -369,18 +407,7 @@ function buildScene(
           },
         ]
       : [],
-    encounterZones: enemyIds.length > 0
-      ? [
-          {
-            id: toStableId("encounter", sceneId),
-            x: layout.encounterZone.x,
-            y: layout.encounterZone.y,
-            width: layout.encounterZone.width,
-            height: layout.encounterZone.height,
-            enemyIds,
-          },
-        ]
-      : [],
+    encounterZones: hasBoss ? [] : buildEncounterZones(sceneId, layout, enemyIds),
     collisionZones: layout.collisionZones.map((zone) => ({
       id: toStableId("collision", `${sceneId}-${zone.id}`),
       x: zone.x,

--- a/packages/game-core/src/types.ts
+++ b/packages/game-core/src/types.ts
@@ -265,6 +265,7 @@ export type FieldMonsterState = {
   texturePath: string;
   x: number;
   y: number;
+  zoneId?: string;
   isBoss: boolean;
   inBattleBy?: string;
   spawnedAt: string;

--- a/packages/game-core/test/content.test.ts
+++ b/packages/game-core/test/content.test.ts
@@ -121,6 +121,44 @@ describe("legacy content conversion", () => {
     expect(convertedEnemy?.spawnRate).toBe(7);
   });
 
+  it("splits monster fields into four visible encounter zones", () => {
+    const world = buildWorldContentFromLegacy({
+      map,
+      monsters: monster,
+      bosses: boss,
+      equipment: equipment as never,
+      skills: skill as never,
+      tactics: tactics as never,
+    });
+
+    const monsterLocations = Object.values(world.locations).filter((location) => (
+      !location.bossName && (world.enemiesByLocation[location.key]?.length ?? 0) > 0
+    ));
+
+    expect(monsterLocations.length).toBeGreaterThan(0);
+    monsterLocations.forEach((location) => {
+      expect(location.scene.encounterZones).toHaveLength(4);
+    });
+  });
+
+  it("does not add normal monster zones to boss-only fields", () => {
+    const world = buildWorldContentFromLegacy({
+      map,
+      monsters: monster,
+      bosses: boss,
+      equipment: equipment as never,
+      skills: skill as never,
+      tactics: tactics as never,
+    });
+
+    const bossLocations = Object.values(world.locations).filter((location) => Boolean(location.bossName));
+
+    expect(bossLocations.length).toBeGreaterThan(0);
+    bossLocations.forEach((location) => {
+      expect(location.scene.encounterZones).toEqual([]);
+    });
+  });
+
   it("creates non-overlapping portal slots when a layout needs more than four exits", () => {
     const layout = createSceneLayout("plaza");
     const slots = createScenePortalSlots(layout, 6);


### PR DESCRIPTION
Summary: Keep the local player sprite authoritative during same-scene syncs to remove hitching near NPCs and portals. Replace pulsing encounter zones with four stable semi-transparent zones and spawn five normal monsters per zone. Let zone monsters wander slowly inside their assigned zone while boss-only fields spawn bosses independently of normal zones. Grant the blacksmith starter sword on NPC dialogue completion. Verification: corepack pnpm -r typecheck, corepack pnpm -r test, corepack pnpm -r lint, corepack pnpm -r build. Manual browser smoke was blocked by local port binding restrictions in this execution environment.