### PR TITLE
Contain shop menus and tune field traversal

### DIFF
--- a/apps/server/test/api.test.ts
+++ b/apps/server/test/api.test.ts
@@ -327,7 +327,7 @@ describe("http api", () => {
     expect(JSON.stringify(duplicateSlotSave.body)).toContain("same equipment slot");
   });
 
-  it("normalizes a blocked saved position to the scene spawn on player load", async () => {
+  it("preserves saved positions on passable obstacle zones during player load", async () => {
     const repository = new MemoryUserRepository();
     const world = createPlayableWorld();
     const context = await createAppContext({
@@ -337,7 +337,7 @@ describe("http api", () => {
     });
 
     const agent = request(context.app);
-    const blockedPlayer = {
+    const obstaclePlayer = {
       ...createStarterPlayer("stuck-hero", world),
       position: { x: 512, y: 384 },
     };
@@ -345,7 +345,7 @@ describe("http api", () => {
     await repository.saveAccount({
       username: "stuck-hero",
       passwordHash: "secret123",
-      player: blockedPlayer,
+      player: obstaclePlayer,
     });
 
     const login = await agent
@@ -359,6 +359,6 @@ describe("http api", () => {
       throw new Error("login response should be successful");
     }
 
-    expect(loginPayload.data.player.position).toEqual({ x: 512, y: 636 });
+    expect(loginPayload.data.player.position).toEqual({ x: 512, y: 384 });
   });
 });

--- a/apps/web/src/game/OverworldScene.ts
+++ b/apps/web/src/game/OverworldScene.ts
@@ -80,6 +80,7 @@ type DeathGraveSprite = {
 const REMOTE_INTERPOLATION_SPEED = 12;
 const REMOTE_SNAP_DISTANCE = 240;
 const LOCAL_PLAYER_SYNC_SNAP_DISTANCE = 96;
+const OBSTACLE_SPEED_MULTIPLIER = 0.35;
 const MONSTER_CONTACT_DISTANCE = 42;
 const BOSS_CONTACT_DISTANCE = 58;
 const GRAVE_INTERACTION_DISTANCE = 58;
@@ -239,11 +240,13 @@ export class OverworldScene extends Phaser.Scene {
       }
     }
 
-    const distance = speed * (delta / 1000);
-    const desiredX = Phaser.Math.Clamp(this.playerSprite.x + velocityX * distance, 36, this.sceneDefinition.width - 36);
-    const desiredY = Phaser.Math.Clamp(this.playerSprite.y + velocityY * distance, 36, this.sceneDefinition.height - 36);
-    const nextX = this.isBlocked(desiredX, this.playerSprite.y) ? this.playerSprite.x : desiredX;
-    const nextY = this.isBlocked(nextX, desiredY) ? this.playerSprite.y : desiredY;
+    const baseDistance = speed * (delta / 1000);
+    const intendedX = Phaser.Math.Clamp(this.playerSprite.x + velocityX * baseDistance, 36, this.sceneDefinition.width - 36);
+    const intendedY = Phaser.Math.Clamp(this.playerSprite.y + velocityY * baseDistance, 36, this.sceneDefinition.height - 36);
+    const speedMultiplier = this.getObstacleSpeedMultiplier(this.playerSprite.x, this.playerSprite.y, intendedX, intendedY);
+    const distance = baseDistance * speedMultiplier;
+    const nextX = Phaser.Math.Clamp(this.playerSprite.x + velocityX * distance, 36, this.sceneDefinition.width - 36);
+    const nextY = Phaser.Math.Clamp(this.playerSprite.y + velocityY * distance, 36, this.sceneDefinition.height - 36);
 
     this.playerSprite.setPosition(nextX, nextY);
     this.playerState = {
@@ -636,8 +639,8 @@ export class OverworldScene extends Phaser.Scene {
     location.scene.encounterZones.forEach((encounterZone) => {
       const zoneCenterX = encounterZone.x + encounterZone.width / 2;
       const zoneCenterY = encounterZone.y + encounterZone.height / 2;
-      const zoneDisplayWidth = Math.max(96, Math.min(encounterZone.width * 0.58, 260));
-      const zoneDisplayHeight = Math.max(58, Math.min(encounterZone.height * 0.72, zoneDisplayWidth * 0.6));
+      const zoneDisplayWidth = Math.max(128, Math.min(encounterZone.width * 0.9, 280));
+      const zoneDisplayHeight = Math.max(82, Math.min(encounterZone.height * 0.9, zoneDisplayWidth * 0.64));
       const encounterMarker = this.add
         .image(
           zoneCenterX,
@@ -645,12 +648,12 @@ export class OverworldScene extends Phaser.Scene {
           location.scene.assets.encounterTexturePath,
         )
         .setDisplaySize(zoneDisplayWidth, zoneDisplayHeight)
-        .setAlpha(0.22)
+        .setAlpha(0.36)
         .setDepth(2);
       this.add
         .image(zoneCenterX, zoneCenterY, location.scene.assets.encounterTexturePath)
-        .setDisplaySize(zoneDisplayWidth * 0.72, zoneDisplayHeight * 0.68)
-        .setAlpha(0.08)
+        .setDisplaySize(zoneDisplayWidth * 0.76, zoneDisplayHeight * 0.72)
+        .setAlpha(0.14)
         .setDepth(3)
         .setBlendMode(Phaser.BlendModes.ADD);
       encounterMarker.setTint(0xc6f6d5);
@@ -1002,10 +1005,16 @@ export class OverworldScene extends Phaser.Scene {
       ?? scene.assets.propsTexturePath;
   }
 
-  private isBlocked(x: number, y: number): boolean {
+  private getObstacleSpeedMultiplier(currentX: number, currentY: number, intendedX: number, intendedY: number): number {
     const size = 20;
-    const hitbox = new Phaser.Geom.Rectangle(x - size / 2, y - size / 2, size, size);
-    return this.collisionZones.some((zone) => Phaser.Geom.Intersects.RectangleToRectangle(hitbox, zone));
+    const currentHitbox = new Phaser.Geom.Rectangle(currentX - size / 2, currentY - size / 2, size, size);
+    const intendedHitbox = new Phaser.Geom.Rectangle(intendedX - size / 2, intendedY - size / 2, size, size);
+    return this.collisionZones.some((zone) => (
+      Phaser.Geom.Intersects.RectangleToRectangle(currentHitbox, zone)
+      || Phaser.Geom.Intersects.RectangleToRectangle(intendedHitbox, zone)
+    ))
+      ? OBSTACLE_SPEED_MULTIPLIER
+      : 1;
   }
 
   private colorForPath(kind?: string): number {

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -99,12 +99,15 @@ button {
   display: grid;
   grid-template-columns: minmax(280px, 360px) minmax(520px, 1fr) minmax(280px, 360px);
   gap: 12px;
+  height: calc(100svh - 112px);
   min-height: calc(100vh - 112px);
+  max-height: calc(100svh - 112px);
 }
 
 .left-ui-shell {
   min-width: 0;
   min-height: 0;
+  height: 100%;
   display: grid;
   grid-template-columns: 64px minmax(0, 1fr);
   gap: 10px;
@@ -147,6 +150,7 @@ button {
 .right-ui-shell {
   min-width: 0;
   min-height: 0;
+  height: 100%;
 }
 
 .right-ui-shell {
@@ -215,7 +219,15 @@ button {
 
 .panel-shell {
   display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
   gap: 14px;
+  height: 100%;
+  min-height: 0;
+}
+
+.panel-shell-body {
+  min-height: 0;
+  overflow: auto;
 }
 
 .left-panel-stack .panel-shell,
@@ -683,15 +695,21 @@ button.dock-card[data-equipment] {
 
 .action-panel .panel-shell-body {
   max-height: none;
-  overflow: auto;
+  overflow: hidden;
   padding-right: 2px;
+}
+
+.action-panel-body {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  gap: 14px;
+  min-height: 0;
 }
 
 .equipment-layout {
   display: grid;
   grid-template-columns: 1fr;
   gap: 12px;
-  margin-top: 14px;
 }
 
 .equipment-board,
@@ -759,6 +777,25 @@ button.dock-card[data-equipment] {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(172px, 1fr));
   gap: 8px;
+}
+
+.shop-board {
+  min-height: 0;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: 10px;
+}
+
+.shop-list {
+  min-height: 0;
+  margin-top: 0;
+  overflow: auto;
+  align-content: start;
+  padding-right: 4px;
+}
+
+.utility-action-grid {
+  margin-top: 0;
 }
 
 .inventory-item.equipped,
@@ -1029,7 +1066,9 @@ button.dock-card[data-equipment] {
 
   .game-layout {
     grid-template-columns: 1fr;
+    height: auto;
     min-height: auto;
+    max-height: none;
   }
 
   .left-ui-shell {

--- a/apps/web/src/ui/dom.ts
+++ b/apps/web/src/ui/dom.ts
@@ -52,6 +52,7 @@ type LayoutGesture =
 type SidePanelKey = Extract<FloatingPanelKey, "action" | "battle" | "log">;
 
 const SIDE_PANEL_KEYS: SidePanelKey[] = ["action", "battle", "log"];
+const SHOP_SUB_LOCATIONS = new Set(["무기 상점", "기술 상점"]);
 
 function escapeHtml(value: unknown): string {
   return String(value)
@@ -78,6 +79,7 @@ export class DomUi {
   private activeSidePanel: SidePanelKey = "action";
   private actionPanelWasVisible = false;
   private battlePanelWasVisible = false;
+  private lastActionLocationKey = "";
   private panelLayouts: Partial<Record<FloatingPanelKey, FloatingPanelLayout>> = {};
   private savedPanelLayouts: Partial<Record<FloatingPanelKey, FloatingPanelLayout>> = {};
   private collapsedPanels: FloatingPanelCollapsedState = {};
@@ -262,6 +264,10 @@ export class DomUi {
       button.classList.toggle("active", isActive);
       button.setAttribute("aria-expanded", String(isActive));
     });
+  }
+
+  private shouldOpenActionPanelOnLocationEntry(location: LocationNode): boolean {
+    return SHOP_SUB_LOCATIONS.has(location.subLocation);
   }
 
   private measurePanelLayout(key: FloatingPanelKey): FloatingPanelLayout | null {
@@ -756,12 +762,16 @@ export class DomUi {
     const { player, battle, battleReport } = state;
     if (!player || !currentLocation) {
       this.actionPanelWasVisible = false;
+      this.lastActionLocationKey = "";
       this.actionPanel.classList.remove("visible");
       this.actionPanel.innerHTML = "";
       return;
     }
 
-    if (!this.actionPanelWasVisible) {
+    const enteredNewLocation = this.lastActionLocationKey !== currentLocation.key;
+    this.lastActionLocationKey = currentLocation.key;
+
+    if (!this.actionPanelWasVisible || (enteredNewLocation && this.shouldOpenActionPanelOnLocationEntry(currentLocation))) {
       this.activeSidePanel = "action";
       this.actionPanelWasVisible = true;
     }
@@ -868,7 +878,34 @@ export class DomUi {
       }).join("")
       : `<div class="inventory-empty">보유한 아이템이 없습니다.</div>`;
 
-    const hasContextActions = restingVisible || equipmentButtons || skillButtons;
+    const hasShopActions = equipmentButtons.length > 0 || skillButtons.length > 0;
+    const shopActionCount = equipmentForLocation.length + skillsForLocation.length;
+    const shopActions = hasShopActions
+      ? `
+        <section class="shop-board" aria-label="상점 판매 목록">
+          <div class="inventory-section-heading">
+            <h3>판매 목록</h3>
+            <span class="pill">${shopActionCount}</span>
+          </div>
+          <div class="dock-grid shop-list">
+            ${equipmentButtons}
+            ${skillButtons}
+          </div>
+        </section>
+      `
+      : "";
+    const utilityCards = [
+      restingVisible ? `<button class="dock-card accent" data-rest><strong>숙박</strong><span>20 코인으로 HP/MP 회복</span></button>` : "",
+      !restingVisible && !hasShopActions ? `<div class="dock-card static"><strong>탐험 구간</strong><span>출구 진입 후 Enter 로 씬 전환, NPC 근처에서 Space 로 대화</span></div>` : "",
+      battle ? `<div class="dock-card static danger"><strong>전투 진행 중</strong><span>오른쪽 전투 오버레이에서 행동을 선택하세요.</span></div>` : "",
+      battleReport ? `
+        <div class="dock-card static ${battleReport.outcome === "enemy_win" ? "danger" : "accent"} report-card">
+          <strong>${escapeHtml(battleReport.title)}</strong>
+          <span>${escapeHtml(battleReport.summary)}</span>
+          <span>최근 전투 로그 ${battleReport.lines.length}개가 오른쪽 패널에 반영되었습니다.</span>
+        </div>
+      ` : "",
+    ].filter(Boolean).join("");
     this.actionPanel.classList.add("visible");
     this.actionPanel.innerHTML = this.renderPanelFrame({
       key: "action",
@@ -902,21 +939,10 @@ export class DomUi {
             </div>
           </section>
         </div>
-        <div class="dock-grid">
-          ${restingVisible ? `<button class="dock-card accent" data-rest><strong>숙박</strong><span>20 코인으로 HP/MP 회복</span></button>` : ""}
-          ${equipmentButtons}
-          ${skillButtons}
-          ${!hasContextActions ? `<div class="dock-card static"><strong>탐험 구간</strong><span>출구 진입 후 Enter 로 씬 전환, NPC 근처에서 Space 로 대화</span></div>` : ""}
-          ${battle ? `<div class="dock-card static danger"><strong>전투 진행 중</strong><span>오른쪽 전투 오버레이에서 행동을 선택하세요.</span></div>` : ""}
-          ${battleReport ? `
-            <div class="dock-card static ${battleReport.outcome === "enemy_win" ? "danger" : "accent"} report-card">
-              <strong>${escapeHtml(battleReport.title)}</strong>
-              <span>${escapeHtml(battleReport.summary)}</span>
-              <span>최근 전투 로그 ${battleReport.lines.length}개가 오른쪽 패널에 반영되었습니다.</span>
-            </div>
-          ` : ""}
-        </div>
+        ${shopActions}
+        ${utilityCards ? `<div class="dock-grid utility-action-grid">${utilityCards}</div>` : ""}
       `,
+      bodyClassName: "action-panel-body",
     });
 
     this.actionPanel.querySelectorAll<HTMLButtonElement>("[data-equipment]").forEach((button) => {

--- a/packages/game-core/src/content/legacy.ts
+++ b/packages/game-core/src/content/legacy.ts
@@ -333,12 +333,12 @@ function buildEncounterZones(
   }
 
   const base = layout.encounterZone;
-  const zoneWidth = Math.min(190, Math.max(128, Math.round(base.width * 0.46)));
-  const zoneHeight = Math.min(118, Math.max(88, Math.round(base.height * 0.5)));
+  const zoneWidth = Math.min(240, Math.max(168, Math.round(base.width * 0.6)));
+  const zoneHeight = Math.min(148, Math.max(108, Math.round(base.height * 0.68)));
   const centerX = base.x + base.width / 2;
   const centerY = base.y + base.height / 2;
-  const offsetX = Math.max(zoneWidth / 2 + 12, Math.round(base.width * 0.26));
-  const offsetY = Math.max(zoneHeight / 2 + 10, Math.round(base.height * 0.28));
+  const offsetX = Math.max(zoneWidth / 2 + 28, Math.round(base.width * 0.32));
+  const offsetY = Math.max(zoneHeight / 2 + 24, Math.round(base.height * 0.36));
   const clamp = (value: number, min: number, max: number): number => Math.min(max, Math.max(min, value));
   const minX = zoneWidth / 2 + 52;
   const maxX = layout.width - zoneWidth / 2 - 52;

--- a/packages/game-core/src/engine/player.ts
+++ b/packages/game-core/src/engine/player.ts
@@ -35,20 +35,6 @@ export function resolveLocationSpawn(world: WorldContent, locationKey: string): 
   return location ? { ...location.scene.spawn } : fallbackPosition();
 }
 
-function isPositionInsideCollision(world: WorldContent, locationKey: string, position: PlayerSave["position"]): boolean {
-  const location = world.locations[locationKey];
-  if (!location) {
-    return false;
-  }
-
-  return location.scene.collisionZones.some((zone) => (
-    position.x >= zone.x
-    && position.x <= zone.x + zone.width
-    && position.y >= zone.y
-    && position.y <= zone.y + zone.height
-  ));
-}
-
 export function normalizePlayerPosition(player: PlayerSave, world: WorldContent): PlayerSave {
   const location = world.locations[player.locationKey];
   if (!location) {
@@ -64,7 +50,7 @@ export function normalizePlayerPosition(player: PlayerSave, world: WorldContent)
     && position.y >= 36
     && position.y <= location.scene.height - 36;
 
-  if (insideBounds && !isPositionInsideCollision(world, player.locationKey, position)) {
+  if (insideBounds) {
     return player;
   }
 

--- a/packages/game-core/test/battle.test.ts
+++ b/packages/game-core/test/battle.test.ts
@@ -237,7 +237,7 @@ describe("battle engine", () => {
     expect(result.logs.some((entry) => entry.includes("슬라임에게 3 피해"))).toBe(true);
   });
 
-  it("places starter and revived players on a safe scene spawn", () => {
+  it("places starter and revived players on a safe scene spawn without rejecting obstacle positions", () => {
     const starter = createStarterPlayer("tester", overworldWorld);
     expect(starter.position).toEqual({ x: 512, y: 636 });
 
@@ -246,7 +246,7 @@ describe("battle engine", () => {
       version: 2,
       position: { x: 512, y: 384 },
     }, "tester", overworldWorld);
-    expect(normalizedExisting.position).toEqual({ x: 512, y: 636 });
+    expect(normalizedExisting.position).toEqual({ x: 512, y: 384 });
 
     const defeatedPlayer = {
       ...starter,

--- a/packages/game-core/test/content.test.ts
+++ b/packages/game-core/test/content.test.ts
@@ -138,6 +138,13 @@ describe("legacy content conversion", () => {
     expect(monsterLocations.length).toBeGreaterThan(0);
     monsterLocations.forEach((location) => {
       expect(location.scene.encounterZones).toHaveLength(4);
+      location.scene.encounterZones.forEach((zone, index) => {
+        expect(zone.width).toBeGreaterThanOrEqual(168);
+        expect(zone.height).toBeGreaterThanOrEqual(108);
+        location.scene.encounterZones.slice(index + 1).forEach((otherZone) => {
+          expect(rectanglesOverlap(zone, otherZone)).toBe(false);
+        });
+      });
     });
   });
 


### PR DESCRIPTION
Summary: entering weapon or skill shops now opens the left action menu, shop sale lists scroll inside the panel instead of stretching the viewport, field obstacles are passable slow zones at 35% speed, saved obstacle positions are preserved, and monster zones are larger/darker with non-overlap coverage. Verification: corepack pnpm -r typecheck, corepack pnpm -r test, corepack pnpm -r lint, corepack pnpm -r build. Manual browser smoke was blocked by local Vite execution restrictions in this environment.